### PR TITLE
Fix wildcard model routing syntax for LiteLLM

### DIFF
--- a/litellm_config_arize.yaml
+++ b/litellm_config_arize.yaml
@@ -3,9 +3,9 @@
 
 model_list:
   # All available Claude models from Anthropic API
-  - model_name: "claude-*"
+  - model_name: "anthropic/*"
     litellm_params:
-      model: "anthropic/{model}"
+      model: "anthropic/*"
       api_key: os.environ/ANTHROPIC_API_KEY
 
 litellm_settings:

--- a/litellm_config_phoenix.yaml
+++ b/litellm_config_phoenix.yaml
@@ -3,9 +3,9 @@
 
 model_list:
   # All available Claude models from Anthropic API
-  - model_name: "claude-*"
+  - model_name: "anthropic/*"
     litellm_params:
-      model: "anthropic/{model}"
+      model: "anthropic/*"
       api_key: os.environ/ANTHROPIC_API_KEY
 
 litellm_settings:


### PR DESCRIPTION
## Summary

- Fixed incorrect wildcard syntax in LiteLLM configuration that was causing 404 errors
- Changed `model_name: "claude-*"` to `"anthropic/*"` 
- Changed `model: "anthropic/{model}"` to `"anthropic/*"`
- Applied fix to both `litellm_config_arize.yaml` and `litellm_config_phoenix.yaml`

## Problem

The previous configuration used `{model}` as a placeholder, which LiteLLM doesn't support. This caused the literal string `{model}` to be sent to Anthropic's API, resulting in errors like:

```
{"type":"error","error":{"type":"not_found_error","message":"model: {model}"}}
```

## Solution

Per [LiteLLM's wildcard routing documentation](https://docs.litellm.ai/docs/wildcard_routing), the correct syntax is `anthropic/*` for both the `model_name` and `litellm_params.model` fields. This allows any Anthropic model (like `claude-sonnet-4-5-20250929`) to be dynamically routed without explicit configuration.

## Testing

- Verified proxy starts successfully with new config
- Confirmed model list shows `['anthropic/*']` in startup logs
- Configuration now matches LiteLLM's documented wildcard syntax