### PR TITLE
Fix Phoenix observability configuration

### DIFF
--- a/litellm_config_phoenix.yaml
+++ b/litellm_config_phoenix.yaml
@@ -33,9 +33,8 @@ router_settings:
   disable_cooldowns: true
   allowed_fails: 1000
 
-# Arize environment configuration
-environment:
-  - ARIZE_API_KEY=${ARIZE_API_KEY}
-  - ARIZE_SPACE_KEY=${ARIZE_SPACE_KEY}
-  - ARIZE_ENDPOINT=https://otlp.arize.com/v1
+# Phoenix environment configuration
+environment_variables:
+  PHOENIX_COLLECTOR_ENDPOINT: "http://phoenix:4317"
+  PHOENIX_COLLECTOR_HTTP_ENDPOINT: "http://phoenix:6006/v1/traces"
 


### PR DESCRIPTION
## Summary
- Fix Phoenix config to use local Phoenix endpoints instead of Arize cloud endpoints
- Change `environment` to `environment_variables` (correct LiteLLM format)
- Set endpoints to `http://phoenix:4317` (gRPC) and `http://phoenix:6006/v1/traces` (HTTP)

## Impact
Users can now properly switch between Arize cloud and Phoenix local observability by changing Docker Compose profiles.