### PR TITLE
Add Arize data export script with date range filtering

### DIFF
--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,11 @@
+# Arize AI Credentials
+# Get these from https://app.arize.com
+
+# Your Arize API key (Settings → API Keys)
+ARIZE_API_KEY=your-arize-api-key-here
+
+# Your Arize Space key/ID (found in space settings)
+ARIZE_SPACE_KEY=your-arize-space-key-here
+
+# Model ID in Arize (should match what's configured in litellm_config_arize.yaml)
+ARIZE_MODEL_ID=litellm

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,15 @@
+# Environment variables (contains secrets)
+.env
+
+# Data exports
+*.csv
+*.parquet
+
+# Python virtual environment
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+
+# UV lock file
+uv.lock

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,135 @@
+# Dev-Agent-Lens Scripts
+
+Utility scripts for managing and analyzing Dev-Agent-Lens data.
+
+## Export Arize Data
+
+Export trace data from Arize AX platform for analysis and reporting.
+
+### Prerequisites
+
+1. **Install dependencies**:
+   ```bash
+   cd scripts
+   uv sync
+   ```
+
+2. **Set environment variables**:
+
+   Copy the example file and add your credentials:
+   ```bash
+   cd scripts
+   cp .env.example .env
+   # Edit .env and add your actual Arize credentials
+   ```
+
+   Alternatively, export them in your shell:
+   ```bash
+   export ARIZE_API_KEY='your-arize-api-key'
+   export ARIZE_SPACE_KEY='your-arize-space-key'
+   export ARIZE_MODEL_ID='dev-agent-lens'  # Optional, defaults to 'dev-agent-lens'
+   ```
+
+### Getting Your Arize Credentials
+
+1. **ARIZE_API_KEY**:
+   - Log in to [Arize Dashboard](https://app.arize.com)
+   - Go to Settings → API Keys
+   - Generate a new API key or copy an existing one
+
+2. **ARIZE_SPACE_KEY**:
+   - In Arize Dashboard, click on your space name in the top navigation
+   - Copy the Space ID (this is your ARIZE_SPACE_KEY)
+
+3. **ARIZE_MODEL_ID**:
+   - This should match the model ID configured in your `litellm_config_arize.yaml`
+   - Default is `dev-agent-lens` (set in `.env.example`)
+
+### Usage Examples
+
+#### Export data for Oct 1, 2025 (default)
+```bash
+uv run python scripts/export_arize_data.py
+```
+
+#### Export all available data
+```bash
+uv run python scripts/export_arize_data.py --all
+```
+
+#### Export data for a custom date range
+```bash
+uv run python scripts/export_arize_data.py --start-date 2025-10-01 --end-date 2025-10-06
+```
+
+#### Export to a specific file
+```bash
+uv run python scripts/export_arize_data.py --output traces_october.csv
+```
+
+#### Export as Parquet format
+```bash
+uv run python scripts/export_arize_data.py --output traces.parquet --format parquet
+```
+
+#### Combine options
+```bash
+uv run python scripts/export_arize_data.py \
+  --start-date 2025-10-01 \
+  --end-date 2025-10-31 \
+  --output october_traces.csv \
+  --format csv
+```
+
+### Output
+
+The script exports trace data to a CSV or Parquet file containing:
+- Span IDs and trace information
+- Timestamps (start/end times)
+- Input/output data
+- Token counts and costs
+- Model information
+- Custom attributes and metadata
+
+### Troubleshooting
+
+**Error: ARIZE_API_KEY environment variable is not set**
+- Ensure you've set the `ARIZE_API_KEY` environment variable or added it to `.env`
+
+**Error: No trace data found**
+- Verify that Dev-Agent-Lens is running and sending traces to Arize
+- Check that the `ARIZE_MODEL_ID` matches what's configured in LiteLLM
+- Ensure the date range contains actual trace data
+- Verify you have access to the Arize space
+
+**Error: Missing required package**
+- Run `cd scripts && uv sync` to install dependencies
+
+### Data Analysis
+
+Once exported, you can analyze the trace data using pandas:
+
+```python
+import pandas as pd
+
+# Load the exported data
+df = pd.read_csv('arize_traces.csv')
+
+# Analyze token usage
+print(df['token_count'].sum())
+
+# Find most expensive traces
+print(df.nlargest(10, 'cost'))
+
+# Group by model
+print(df.groupby('model_name')['token_count'].sum())
+```
+
+## Adding More Scripts
+
+To add new utility scripts to this folder:
+
+1. Create your script in the `scripts/` directory
+2. Add any new dependencies to `requirements.txt`
+3. Update this README with usage documentation
+4. Make the script executable: `chmod +x scripts/your_script.py`

--- a/scripts/export_arize_data.py
+++ b/scripts/export_arize_data.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Export Arize Trace Data Script
+
+This script exports trace data from Arize AX platform for the Dev-Agent-Lens project.
+It supports both date range filtering and exporting all available data.
+
+Environment Variables Required:
+    ARIZE_API_KEY: Your Arize API key
+    ARIZE_SPACE_KEY: Your Arize space key (space_id)
+    ARIZE_MODEL_ID: Model ID in Arize (default: 'dev-agent-lens')
+
+Usage Examples:
+    # Export data for Oct 1, 2025 (default)
+    uv run python scripts/export_arize_data.py
+
+    # Export all available data
+    uv run python scripts/export_arize_data.py --all
+
+    # Export data for a custom date range
+    uv run python scripts/export_arize_data.py --start-date 2025-10-01 --end-date 2025-10-06
+
+    # Export to a specific file
+    uv run python scripts/export_arize_data.py --output traces_oct.csv
+
+    # Export as Parquet
+    uv run python scripts/export_arize_data.py --output traces.parquet --format parquet
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+try:
+    from arize.exporter import ArizeExportClient
+    from arize.utils.types import Environments
+    import pandas as pd
+    from dotenv import load_dotenv
+except ImportError as e:
+    print(f"❌ Missing required package: {e}")
+    print("\nPlease install required packages:")
+    print("  cd scripts && uv sync")
+    sys.exit(1)
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Export trace data from Arize AX for Dev-Agent-Lens project",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument(
+        '--start-date',
+        type=str,
+        help='Start date in ISO format (YYYY-MM-DD). Default: 2025-10-01'
+    )
+
+    parser.add_argument(
+        '--end-date',
+        type=str,
+        help='End date in ISO format (YYYY-MM-DD). Default: end of start date'
+    )
+
+    parser.add_argument(
+        '--all',
+        action='store_true',
+        help='Export all available data (ignores date filters)'
+    )
+
+    parser.add_argument(
+        '--output',
+        type=str,
+        default='arize_traces.csv',
+        help='Output file path (default: arize_traces.csv)'
+    )
+
+    parser.add_argument(
+        '--format',
+        type=str,
+        choices=['csv', 'parquet'],
+        default='csv',
+        help='Output format (default: csv)'
+    )
+
+    return parser.parse_args()
+
+
+def load_environment():
+    """Load and validate environment variables."""
+    # Load from .env file if it exists (check scripts/.env first, then root .env)
+    script_env = Path(__file__).parent / '.env'
+    root_env = Path(__file__).parent.parent / '.env'
+
+    if script_env.exists():
+        load_dotenv(script_env)
+    elif root_env.exists():
+        load_dotenv(root_env)
+
+    # Validate required environment variables
+    api_key = os.getenv('ARIZE_API_KEY')
+    space_key = os.getenv('ARIZE_SPACE_KEY')
+    model_id = os.getenv('ARIZE_MODEL_ID', 'dev-agent-lens')
+
+    if not api_key:
+        print("❌ Error: ARIZE_API_KEY environment variable is not set")
+        print("\nPlease set your Arize API key:")
+        print("  export ARIZE_API_KEY='your-api-key-here'")
+        print("\nOr add it to your .env file:")
+        print("  ARIZE_API_KEY=your-api-key-here")
+        sys.exit(1)
+
+    if not space_key:
+        print("❌ Error: ARIZE_SPACE_KEY environment variable is not set")
+        print("\nPlease set your Arize space key:")
+        print("  export ARIZE_SPACE_KEY='your-space-key-here'")
+        print("\nOr add it to your .env file:")
+        print("  ARIZE_SPACE_KEY=your-space-key-here")
+        sys.exit(1)
+
+    return api_key, space_key, model_id
+
+
+def parse_date(date_str: str) -> datetime:
+    """Parse ISO date string to datetime."""
+    try:
+        return datetime.fromisoformat(date_str)
+    except ValueError:
+        print(f"❌ Error: Invalid date format '{date_str}'. Use YYYY-MM-DD format.")
+        sys.exit(1)
+
+
+def export_traces(args):
+    """Export trace data from Arize."""
+    # Load environment
+    api_key, space_key, model_id = load_environment()
+
+    # Initialize Arize export client with explicit API key
+    print("🔄 Initializing Arize export client...")
+    client = ArizeExportClient(api_key=api_key)
+
+    # Prepare export parameters
+    export_params = {
+        'space_id': space_key,
+        'model_id': model_id,
+        'environment': Environments.TRACING,
+    }
+
+    # Configure date range
+    if not args.all:
+        if args.start_date:
+            start_date = parse_date(args.start_date)
+        else:
+            # Default to Oct 1, 2025
+            start_date = datetime(2025, 10, 1)
+
+        if args.end_date:
+            end_date = parse_date(args.end_date)
+        else:
+            # Default to end of start date
+            end_date = start_date + timedelta(days=1)
+
+        export_params['start_time'] = start_date
+        export_params['end_time'] = end_date
+
+        print(f"📅 Exporting traces from {start_date.date()} to {end_date.date()}")
+    else:
+        print("📅 Exporting all available traces")
+
+    # Export data
+    print(f"🔄 Fetching trace data from Arize (model_id: {model_id})...")
+    try:
+        df = client.export_model_to_df(**export_params)
+
+        if df.empty:
+            print("⚠️  No trace data found for the specified criteria")
+            print("\nTroubleshooting:")
+            print(f"  - Verify model_id '{model_id}' exists in Arize")
+            print(f"  - Check date range contains data")
+            print(f"  - Ensure traces are being sent to Arize from Dev-Agent-Lens")
+            return
+
+        print(f"✅ Retrieved {len(df)} trace records")
+
+        # Save to file
+        output_path = Path(args.output)
+
+        if args.format == 'parquet':
+            df.to_parquet(output_path, index=False)
+        else:
+            df.to_csv(output_path, index=False)
+
+        print(f"💾 Exported data to: {output_path.absolute()}")
+
+        # Print summary
+        print(f"\n📊 Data Summary:")
+        print(f"  Total records: {len(df)}")
+        print(f"  Columns: {', '.join(df.columns.tolist()[:5])}{'...' if len(df.columns) > 5 else ''}")
+        print(f"  File size: {output_path.stat().st_size / 1024:.2f} KB")
+
+        # Show preview
+        print(f"\n🔍 First 3 records preview:")
+        print(df.head(3).to_string())
+
+    except Exception as e:
+        print(f"❌ Error exporting data: {e}")
+        print("\nTroubleshooting:")
+        print("  - Verify ARIZE_API_KEY and ARIZE_SPACE_KEY are correct")
+        print("  - Check that the model_id exists in Arize")
+        print("  - Ensure you have access to the Arize space")
+        sys.exit(1)
+
+
+def main():
+    """Main entry point."""
+    args = parse_args()
+    export_traces(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "dev-agent-lens-scripts"
+version = "1.0.0"
+description = "Utility scripts for Dev-Agent-Lens data export and analysis"
+requires-python = ">=3.10"
+dependencies = [
+    "arize>=7.0.3",
+    "pandas>=2.0.0",
+    "python-dotenv>=1.0.0",
+    "pyarrow>=14.0.0",
+    "packaging>=24.0",
+    "openinference-semantic-conventions>=0.1.0",
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-semantic-conventions>=0.42b0",
+]


### PR DESCRIPTION
Implements ENG2-393 to create a working example script to pull data from Arize. The script supports:
- Date range filtering (defaults to Oct 1, 2025)
- Option to export all data with --all flag
- CSV and Parquet output formats
- Environment-based configuration via .env file

🤖 Generated with [Claude Code](https://claude.com/claude-code)