### PR TITLE
Fix Phoenix data persistence and rename service to dev-agent-lens

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
     environment:
       - PHOENIX_PORT=6006
       - PHOENIX_HOST=0.0.0.0
+      - PHOENIX_WORKING_DIR=/mnt/data
     volumes:
       - phoenix_data:/mnt/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- **Rename service** from `litellm-proxy` to `dev-agent-lens` across all OTEL service names, Arize model IDs, and resource attributes
- **Fix Phoenix data loss on restart** by adding `PHOENIX_WORKING_DIR=/mnt/data` to the Phoenix service environment

## Problem

Phoenix stores its SQLite database in `~/.phoenix/` by default (inside the container). Even though a persistent volume was mounted at `/mnt/data`, Phoenix wasn't using it — data lived in ephemeral container storage and was lost on every `docker compose down` or container restart.

## Fix

Added one environment variable to the Phoenix service:

```yaml
environment:
  - PHOENIX_WORKING_DIR=/mnt/data  # Tell Phoenix to use the mounted volume
```

## Validation

- Tested migration of 6GB production database to persistent volume
- Verified data survives full `docker compose down` / `up` cycle (581,887 spans preserved)
- Ran E2E testbed to confirm traces flow through the pipeline after the fix
- No data loss observed

## Test plan

- [ ] Start Phoenix profile: `docker compose --profile phoenix up -d`
- [ ] Send traces through LiteLLM proxy
- [ ] Verify traces appear in Phoenix UI at http://localhost:6006
- [ ] Run `docker compose --profile phoenix down` then `up -d`
- [ ] Verify traces are still present after restart