### PR TITLE
Fix: Add explicit provider to wildcard patterns for new Claude models

### DIFF
--- a/litellm_config_arize.yaml
+++ b/litellm_config_arize.yaml
@@ -2,17 +2,56 @@
 # This allows Claude Code to select any model while maintaining observability
 
 model_list:
-  # Claude models with explicit provider prefix
+  # Explicit model entries for known models with provider specified
+  - model_name: "claude-opus-4-6"
+    litellm_params:
+      model: "claude-opus-4-6"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  - model_name: "claude-sonnet-4-5"
+    litellm_params:
+      model: "claude-sonnet-4-5"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  - model_name: "claude-haiku-4-5"
+    litellm_params:
+      model: "claude-haiku-4-5"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  # Anthropic-prefixed models
   - model_name: "anthropic/*"
     litellm_params:
       model: "anthropic/*"
       api_key: os.environ/ANTHROPIC_API_KEY
 
-  # Route unprefixed claude-* models to Anthropic provider
+  # Claude with versions (covers claude-opus-*, claude-sonnet-*, etc.)
+  - model_name: "claude-opus-*"
+    litellm_params:
+      model: "claude-opus-*"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  - model_name: "claude-sonnet-*"
+    litellm_params:
+      model: "claude-sonnet-*"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  - model_name: "claude-haiku-*"
+    litellm_params:
+      model: "claude-haiku-*"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  # Broad Claude catch-all
   - model_name: "claude-*"
     litellm_params:
-      model: "anthropic/claude-*"
+      model: "claude-*"
       api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
 
 litellm_settings:
   # Enable Arize AX callbacks for cloud observability

--- a/litellm_config_phoenix.yaml
+++ b/litellm_config_phoenix.yaml
@@ -2,17 +2,56 @@
 # This allows Claude Code to select any model while maintaining observability
 
 model_list:
-  # Claude models with explicit provider prefix
+  # Explicit model entries for known models with provider specified
+  - model_name: "claude-opus-4-6"
+    litellm_params:
+      model: "claude-opus-4-6"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  - model_name: "claude-sonnet-4-5"
+    litellm_params:
+      model: "claude-sonnet-4-5"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  - model_name: "claude-haiku-4-5"
+    litellm_params:
+      model: "claude-haiku-4-5"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  # Anthropic-prefixed models
   - model_name: "anthropic/*"
     litellm_params:
       model: "anthropic/*"
       api_key: os.environ/ANTHROPIC_API_KEY
 
-  # Route unprefixed claude-* models to Anthropic provider
+  # Claude with versions (covers claude-opus-*, claude-sonnet-*, etc.)
+  - model_name: "claude-opus-*"
+    litellm_params:
+      model: "claude-opus-*"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  - model_name: "claude-sonnet-*"
+    litellm_params:
+      model: "claude-sonnet-*"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  - model_name: "claude-haiku-*"
+    litellm_params:
+      model: "claude-haiku-*"
+      api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
+
+  # Broad Claude catch-all
   - model_name: "claude-*"
     litellm_params:
-      model: "anthropic/claude-*"
+      model: "claude-*"
       api_key: os.environ/ANTHROPIC_API_KEY
+      custom_llm_provider: "anthropic"
 
 litellm_settings:
   # Enable Arize Phoenix callbacks for local observability
@@ -43,4 +82,3 @@ router_settings:
 environment_variables:
   PHOENIX_COLLECTOR_ENDPOINT: "http://phoenix:4317"
   PHOENIX_COLLECTOR_HTTP_ENDPOINT: "http://phoenix:6006/v1/traces"
-


### PR DESCRIPTION
The recent update to main added claude-* wildcard routing, but it's missing the critical custom_llm_provider parameter. Without this, LiteLLM still fails with 'LLM Provider NOT provided' errors for new models like claude-opus-4-6.

This commit adds:
- Explicit entries for current models (opus-4-6, sonnet-4-5, haiku-4-5)
- Wildcard patterns for each model family with custom_llm_provider
- Broad claude-* catch-all with explicit provider specification

The custom_llm_provider: 'anthropic' parameter is critical for wildcards to work correctly. Without it, LiteLLM cannot determine which provider to route requests to, causing authentication and routing failures.

Testing:
- Production environment (port 4000): 7/7 models passing
- Test environment (4110-4113): All configs verified
- OAuth authentication: Confirmed working
- Models tested: claude-opus-4-6, claude-sonnet-4-5, claude-haiku-4-5, timestamped variants, and prefixed formats

Fixes: ENG2-809
Completes: PR #15