### PR TITLE
feat(phoenix): support external Postgres backend + fix OTLP HTTP endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,22 @@ ARIZE_MODEL_VERSION=local-dev
 # POSTGRES_PASSWORD=your-secure-password
 # STORE_MODEL_IN_DB=true
 
+# --- Phoenix backend storage ---
+# When set, Phoenix uses external Postgres (e.g. Supabase) instead of in-process
+# SQLite. Use the SESSION pooler connection string from Supabase (port 5432 on
+# pooler.supabase.com). Direct connection is IPv6-only by default; transaction
+# pooling breaks Phoenix's prepared-statement use. Session pooler is the
+# correct choice. Leave unset to fall back to SQLite.
+# PHOENIX_SQL_DATABASE_URL=postgresql://postgres.<project-ref>:<password>@aws-1-us-east-1.pooler.supabase.com:5432/postgres
+
+# Optional: schema for Phoenix tables (auto-created on first connect).
+# Defaults to "phoenix" — leave commented unless you need a different name.
+# PHOENIX_SQL_DATABASE_SCHEMA=phoenix
+
 # ==============================================================================
 # Usage:
 # - Basic Setup: Set ANTHROPIC_API_KEY and Arize keys (ARIZE_API_KEY, ARIZE_SPACE_KEY)
 # - Advanced Setup: Also uncomment desired optional features, use docker-compose.yml --profile advanced
+# - Phoenix-on-Postgres: Set PHOENIX_SQL_DATABASE_URL (see above) to
+#   put Phoenix on external Supabase Postgres instead of in-process SQLite.
 # ==============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,9 +59,14 @@ services:
       - OTEL_SERVICE_NAME=${PHOENIX_PROJECT:-${CLAUDE_LENS_PROJECT:-dev-agent-lens}}
 
       # Phoenix OTLP endpoint
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:4317
-      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-      - PHOENIX_COLLECTOR_ENDPOINT=http://phoenix:4317
+      # Use Phoenix's HTTP OTLP endpoint (port 6006/v1/traces),
+      # not the gRPC endpoint (port 4317). LiteLLM's arize_phoenix callback
+      # uses requests/HTTP under the hood — pointing at the gRPC port causes
+      # silent span drops with "Custom Logger Error" tracebacks. Phoenix
+      # accepts OTLP/HTTP at /v1/traces on its UI port.
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:6006/v1/traces
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - PHOENIX_COLLECTOR_ENDPOINT=http://phoenix:6006
 
       # Give the resource a name so you can filter by service
       # openinference.project.name determines the project in Phoenix UI
@@ -84,6 +89,11 @@ services:
   # Phoenix observability server (use with --profile phoenix)
   phoenix:
     image: arizephoenix/phoenix:latest
+    # arizephoenix/phoenix:latest's linux/arm64 build crashes on Apple Silicon
+    # with SIGILL (exit 132) before producing any log output. The linux/amd64
+    # build runs fine under Rosetta emulation. Pin platform until the upstream
+    # arm64 image is fixed.
+    platform: linux/amd64
     ports:
       - "6006:6006" # Phoenix UI
       - "4317:4317" # OTLP gRPC endpoint
@@ -91,6 +101,13 @@ services:
       - PHOENIX_PORT=6006
       - PHOENIX_HOST=0.0.0.0
       - PHOENIX_WORKING_DIR=/mnt/data
+      # when PHOENIX_SQL_DATABASE_URL is set in .env Phoenix uses
+      # external Supabase Postgres as its backend instead of in-process SQLite.
+      # Phoenix auto-creates its schema (named via PHOENIX_SQL_DATABASE_SCHEMA,
+      # defaulting to "phoenix") on first connect. Leave PHOENIX_SQL_DATABASE_URL
+      # unset to fall back to SQLite under PHOENIX_WORKING_DIR (legacy behavior).
+      - PHOENIX_SQL_DATABASE_URL=${PHOENIX_SQL_DATABASE_URL:-}
+      - PHOENIX_SQL_DATABASE_SCHEMA=${PHOENIX_SQL_DATABASE_SCHEMA:-phoenix}
     volumes:
       - phoenix_data:/mnt/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Phoenix now reads \`PHOENIX_SQL_DATABASE_URL\` and \`PHOENIX_SQL_DATABASE_SCHEMA\` from \`.env\` to migrate from in-process SQLite to external Postgres (e.g. Supabase). Phoenix auto-creates its schema on first connect and runs alembic migrations. Defaults preserve legacy SQLite behavior when the env var is unset.
- Fixes the \`litellm-proxy-phoenix\` OTLP endpoint: was pointing at port 4317 (gRPC) but LiteLLM's \`arize_phoenix\` callback uses an HTTP exporter, which silently fails against a gRPC listener. Switch to Phoenix's HTTP OTLP endpoint at port 6006/v1/traces with protocol \`http/protobuf\`.
- Pin phoenix to \`platform: linux/amd64\`. The arm64 build of \`arizephoenix/phoenix:latest\` crashes on Apple Silicon with SIGILL (exit 132) before producing any log output. The amd64 build runs fine under Rosetta emulation.
- \`.env.example\` documents the new vars with guidance on which Supabase connection string to use (Session pooler on port 5432, IPv4-compatible, prepared-statement-safe).

## Verification

End-to-end: spans land in \`phoenix.spans\` / \`phoenix.traces\` in Postgres with linear-emit shape preserved (44 spans / 24 traces captured against a live Supabase project, all under \`dev-agent-lens\` project, span names show post-patch \`Claude_Code_Internal_Prompt_0\` only — no \`_1..N\` re-emission).

## Test plan

- [x] \`docker compose --profile phoenix up -d\` starts Phoenix on Supabase Postgres
- [x] Phoenix UI loads at \`http://localhost:6006\`
- [x] Phoenix migrations create \~50 tables in the \`phoenix\` schema
- [x] LiteLLM proxy emits OTLP/HTTP successfully (\`200 OK\` on \`/v1/traces\`)
- [x] Spans land in Postgres tied to the correct project
- [x] Falls back to SQLite when \`PHOENIX_SQL_DATABASE_URL\` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)