### PR TITLE
chore: disable Greptile auto-review to reduce per-PR cost

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,3 @@
+{
+  "skipReview": "AUTOMATIC"
+}


### PR DESCRIPTION
Adds `greptile.json` with `skipReview: AUTOMATIC`. Stops Greptile from auto-reviewing every push; `@greptile` mentions still work for explicit on-demand reviews.

Per Alex — public DAL doesn't need auto-review running on every iteration.