### PR TITLE
ENG2-1153: DAL phoenix-postgres source — direct Postgres reads, CLI wiring, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,33 @@ dal export-parquet --source my-phoenix
 
 Data is stored in `~/.dal/data/parquet/`. Run `dal sync --help` for all options.
 
+#### Phoenix on Postgres (recommended for shared backends)
+
+When Phoenix is configured to use external Postgres (e.g. Supabase) instead of
+in-process SQLite, DAL can read straight from the database — bypassing
+Phoenix's REST API entirely. This is faster and avoids Phoenix's GraphQL
+timeout on large pulls.
+
+```bash
+# Add the source. --connection-url and --schema fall back to
+# PHOENIX_SQL_DATABASE_URL / PHOENIX_SQL_DATABASE_SCHEMA env vars,
+# so you don't need to paste the password on the command line.
+dal config add-source phoenix-supabase --type phoenix-postgres \
+    --project dev-agent-lens --shared
+
+# Or pass them explicitly:
+dal config add-source phoenix-supabase --type phoenix-postgres \
+    --connection-url "postgresql://user:pass@host.pooler.supabase.com:5432/postgres" \
+    --schema phoenix --project dev-agent-lens --shared
+
+# Sync — same UX as the REST source
+dal sync --source phoenix-supabase
+```
+
+Use Supabase's **Session pooler** connection string (port 5432 on
+`*.pooler.supabase.com`). The Direct connection is IPv6-only and the
+Transaction pooler breaks Phoenix's prepared-statement use.
+
 ### Querying Data
 
 ```bash

--- a/dev_agent_lens/cli/main.py
+++ b/dev_agent_lens/cli/main.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 from dev_agent_lens.clients.arize import ArizeClient
 from dev_agent_lens.clients.phoenix import PhoenixClient
+from dev_agent_lens.clients.phoenix_postgres import PhoenixPostgresClient
 from dev_agent_lens.clients.phoenix_sqlite import PhoenixSQLiteClient
 from dev_agent_lens.core.schema import (
     normalize_arize,
@@ -49,6 +50,12 @@ BACKENDS = {
         "client_class": PhoenixClient,
         "normalizer": normalize_phoenix,
         "env_check": "DAL_PHOENIX_URL",
+    },
+    "phoenix-postgres": {
+        "name": "Phoenix on Postgres",
+        "client_class": PhoenixPostgresClient,
+        "normalizer": normalize_phoenix,
+        "env_check": "PHOENIX_SQL_DATABASE_URL",
     },
     "arize-cloud": {
         "name": "Arize Cloud",
@@ -708,8 +715,10 @@ def sync(
         # Create source-specific store
         source_store = OxenStore.for_source(source.name)
 
-        # Set up environment and determine client/normalizer
-        sqlite_client = None
+        # Set up environment and determine client/normalizer.
+        # `direct_client` short-circuits the REST client when we're reading
+        # straight from a Phoenix-backing DB (SQLite via Docker, or Postgres).
+        direct_client = None
 
         if source.source_type == SourceType.PHOENIX:
             if source.url:
@@ -719,12 +728,12 @@ def sync(
 
             if use_sqlite and resolved_sqlite_container:
                 db_path = f"docker://{resolved_sqlite_container}:/root/.phoenix/phoenix.db"
-                sqlite_client = PhoenixSQLiteClient(
+                direct_client = PhoenixSQLiteClient(
                     db_path=db_path,
                     project=source.project or os.getenv("DAL_PHOENIX_PROJECT", "dev-agent-lens"),
                 )
                 try:
-                    if not sqlite_client.test_connection():
+                    if not direct_client.test_connection():
                         click.echo(click.style(
                             f"Error: Could not connect to Phoenix SQLite database",
                             fg="red",
@@ -735,6 +744,29 @@ def sync(
                     return 0, 0, 1
 
             client_class = PhoenixClient
+            normalizer_fn = normalize_phoenix
+            is_phoenix = True
+        elif source.source_type == SourceType.PHOENIX_POSTGRES:
+            direct_client = PhoenixPostgresClient(
+                connection_url=source.connection_url,
+                project=source.project or os.getenv("DAL_PHOENIX_PROJECT", "dev-agent-lens"),
+                schema=source.schema or os.getenv("PHOENIX_SQL_DATABASE_SCHEMA", "phoenix"),
+                timeout=int(timeout),
+            )
+            try:
+                if not direct_client.test_connection():
+                    click.echo(click.style(
+                        f"Error: Could not reach Phoenix Postgres or project "
+                        f"'{source.project}' not found in schema "
+                        f"'{source.schema or 'phoenix'}'",
+                        fg="red",
+                    ))
+                    return 0, 0, 1
+            except Exception as e:
+                click.echo(click.style(f"Error: Postgres connection test failed: {e}", fg="red"))
+                return 0, 0, 1
+
+            client_class = PhoenixClient  # unused — direct_client overrides
             normalizer_fn = normalize_phoenix
             is_phoenix = True
         else:  # ARIZE
@@ -750,12 +782,12 @@ def sync(
         if use_checkpointing:
             return _process_with_checkpointing(
                 source, source_start, source_end,
-                source_store, client_class, normalizer_fn, is_phoenix, sqlite_client
+                source_store, client_class, normalizer_fn, is_phoenix, direct_client
             )
         else:
             return _process_lightweight(
                 source, source_start, source_end,
-                source_store, client_class, normalizer_fn, is_phoenix, sqlite_client
+                source_store, client_class, normalizer_fn, is_phoenix, direct_client
             )
 
     def _process_lightweight(
@@ -766,14 +798,14 @@ def sync(
         client_class: type,
         normalizer_fn,
         is_phoenix: bool,
-        sqlite_client=None,
+        direct_client=None,
     ) -> tuple[int, int, int]:
         """Lightweight sync without checkpointing (for small syncs < 7 days)."""
         click.echo(f"[{source.name}] Starting sync (lightweight mode)...")
 
         # Create client
-        if sqlite_client:
-            client = sqlite_client
+        if direct_client:
+            client = direct_client
         elif is_phoenix:
             client = client_class(timeout=float(timeout))
         else:
@@ -853,7 +885,7 @@ def sync(
         client_class: type,
         normalizer_fn,
         is_phoenix: bool,
-        sqlite_client=None,
+        direct_client=None,
     ) -> tuple[int, int, int]:
         """Robust sync with checkpointing (for large syncs >= 7 days)."""
 
@@ -874,8 +906,8 @@ def sync(
             click.echo(f"[{source.name}] Starting sync (robust mode with checkpointing)...")
 
         # Create client
-        if sqlite_client:
-            client = sqlite_client
+        if direct_client:
+            client = direct_client
         elif is_phoenix:
             client = client_class(timeout=float(timeout))
         else:
@@ -1245,9 +1277,9 @@ def config_show() -> None:
 @click.option(
     "--type",
     "source_type",
-    type=click.Choice(["phoenix", "arize"]),
+    type=click.Choice(["phoenix", "phoenix-postgres", "arize"]),
     required=True,
-    help="Type of backend (phoenix or arize)",
+    help="Type of backend (phoenix, phoenix-postgres, or arize)",
 )
 @click.option(
     "--url",
@@ -1274,6 +1306,16 @@ def config_show() -> None:
     "--sqlite-container",
     help="Docker container name for direct SQLite access (Phoenix only)",
 )
+@click.option(
+    "--connection-url",
+    help="Postgres connection string (phoenix-postgres only). "
+    "Falls back to PHOENIX_SQL_DATABASE_URL env var.",
+)
+@click.option(
+    "--schema",
+    help="Postgres schema for Phoenix tables (phoenix-postgres only, default 'phoenix'). "
+    "Falls back to PHOENIX_SQL_DATABASE_SCHEMA env var.",
+)
 def config_add_source(
     name: str,
     source_type: str,
@@ -1283,6 +1325,8 @@ def config_add_source(
     model_id: str | None,
     local_only: bool,
     sqlite_container: str | None,
+    connection_url: str | None,
+    schema: str | None,
 ) -> None:
     """Add a new named source.
 
@@ -1293,8 +1337,18 @@ def config_add_source(
         dal config add-source arize-team --type arize --space-key ABC --model-id my-model --shared
 
         dal config add-source phoenix-docker --type phoenix --url localhost:6006 --sqlite-container dev-agent-lens-phoenix-1
+
+        dal config add-source phoenix-supabase --type phoenix-postgres \\
+            --connection-url "postgres://user:pass@host:5432/postgres" \\
+            --schema phoenix --project dev-agent-lens --shared
     """
     from dev_agent_lens.core.sources import SourceConfig, SourceManager, SourceType
+
+    # phoenix-postgres can fall back to env vars for connection_url/schema
+    # so users don't have to paste secrets on the command line
+    if source_type == "phoenix-postgres":
+        connection_url = connection_url or os.getenv("PHOENIX_SQL_DATABASE_URL")
+        schema = schema or os.getenv("PHOENIX_SQL_DATABASE_SCHEMA", "phoenix")
 
     # Create source config
     source = SourceConfig(
@@ -1304,6 +1358,8 @@ def config_add_source(
         url=url,
         project=project,
         sqlite_container=sqlite_container,
+        connection_url=connection_url,
+        schema=schema,
         space_key=space_key,
         model_id=model_id,
     )

--- a/dev_agent_lens/clients/phoenix_postgres.py
+++ b/dev_agent_lens/clients/phoenix_postgres.py
@@ -1,0 +1,294 @@
+"""
+Phoenix Postgres client.
+
+Reads span data directly from a Phoenix-on-Postgres backend (e.g. Supabase),
+mirroring the surface of `PhoenixSQLiteClient` so `dal sync` and downstream
+tooling work without code changes when switching from SQLite to Postgres.
+
+Use when Phoenix is configured with `PHOENIX_SQL_DATABASE_URL=postgres://...`
+(see ENG2-817). Tables live in a configurable schema (default `phoenix`).
+
+Example:
+    client = PhoenixPostgresClient(
+        connection_url="postgres://...@aws-1-us-east-1.pooler.supabase.com:5432/postgres",
+        project="dev-agent-lens",
+        schema="phoenix",
+    )
+    df = client.get_spans_dataframe(start_time=..., end_time=..., limit=1000)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class PhoenixPostgresError(Exception):
+    """Base exception for Phoenix Postgres client errors."""
+
+
+class PhoenixPostgresConnectionError(PhoenixPostgresError):
+    """Raised when the client can't reach the Postgres server."""
+
+
+class PhoenixPostgresQueryError(PhoenixPostgresError):
+    """Raised when a query fails to execute."""
+
+
+class PhoenixPostgresClient:
+    """Direct Postgres reader for a Phoenix span store.
+
+    Mirrors the surface of `PhoenixSQLiteClient` so the rest of DAL doesn't
+    care which backend Phoenix is on.
+
+    Notes:
+        - Connections use `psycopg` (v3). Add `psycopg[binary]` to deps.
+        - Phoenix's tables live in a configurable schema (default `phoenix`).
+          The schema is set via `PHOENIX_SQL_DATABASE_SCHEMA` on the Phoenix
+          container; this client must match.
+        - `attributes` and `events` are JSONB in Postgres — returned as dicts,
+          unlike the JSON-string of the SQLite path. Callers should treat
+          both as dicts for forward-compat.
+        - Use Supabase's Session pooler (port 5432 on `*.pooler.supabase.com`)
+          for IPv4 + prepared-statement compatibility.
+    """
+
+    def __init__(
+        self,
+        connection_url: str,
+        project: str = "dev-agent-lens",
+        schema: str = "phoenix",
+        timeout: int = 30,
+    ) -> None:
+        try:
+            import psycopg  # noqa: F401
+        except ImportError as e:
+            raise PhoenixPostgresError(
+                "psycopg (v3) is required. Install with: uv add 'psycopg[binary]'"
+            ) from e
+
+        self.connection_url = connection_url
+        self.project = project
+        self.schema = schema
+        self.timeout = timeout
+        self._conn: Any = None
+
+    def _get_connection(self) -> Any:
+        """Open and cache a connection. Reconnects if the cached one is dead."""
+        import psycopg
+
+        if self._conn is None or self._conn.closed:
+            try:
+                self._conn = psycopg.connect(
+                    self.connection_url,
+                    connect_timeout=self.timeout,
+                    autocommit=True,
+                )
+                with self._conn.cursor() as cur:
+                    cur.execute(f"SET search_path TO {self.schema}, public")
+            except Exception as e:
+                raise PhoenixPostgresConnectionError(
+                    f"Failed to connect to Postgres: {e}"
+                ) from e
+        return self._conn
+
+    def _execute_query(
+        self, query: str, params: tuple[Any, ...] | None = None
+    ) -> list[dict[str, Any]]:
+        from psycopg.rows import dict_row
+
+        try:
+            conn = self._get_connection()
+            with conn.cursor(row_factory=dict_row) as cur:
+                cur.execute(query, params or ())
+                return list(cur.fetchall())
+        except PhoenixPostgresConnectionError:
+            raise
+        except Exception as e:
+            raise PhoenixPostgresQueryError(f"Query failed: {e}") from e
+
+    def get_spans_dataframe(
+        self,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> pd.DataFrame:
+        """Fetch spans for the configured project as a DataFrame.
+
+        Returns the same columns as `PhoenixSQLiteClient.get_spans_dataframe` so
+        downstream code is backend-agnostic.
+        """
+        query = """
+            SELECT
+                s.span_id AS "context.span_id",
+                t.trace_id AS "context.trace_id",
+                s.parent_id,
+                s.name,
+                s.span_kind,
+                s.start_time,
+                s.end_time,
+                s.status_code,
+                s.status_message,
+                s.attributes,
+                s.events,
+                s.cumulative_error_count,
+                s.cumulative_llm_token_count_prompt,
+                s.cumulative_llm_token_count_completion,
+                s.llm_token_count_prompt,
+                s.llm_token_count_completion
+            FROM spans s
+            JOIN traces t ON s.trace_rowid = t.id
+            JOIN projects p ON t.project_rowid = p.id
+            WHERE p.name = %s
+        """
+        params: list[Any] = [self.project]
+
+        if start_time is not None:
+            query += " AND s.start_time >= %s"
+            params.append(start_time)
+        if end_time is not None:
+            query += " AND s.start_time < %s"
+            params.append(end_time)
+
+        query += " ORDER BY s.start_time ASC"
+
+        if limit is not None:
+            query += " LIMIT %s"
+            params.append(limit)
+        if offset:
+            query += " OFFSET %s"
+            params.append(offset)
+
+        rows = self._execute_query(query, tuple(params))
+        df = pd.DataFrame(rows)
+
+        # Match SQLite client output: serialize JSONB to strings so callers
+        # that parse with json.loads keep working. Future cleanup: have all
+        # backends return dicts and update callers.
+        for col in ("attributes", "events"):
+            if col in df.columns:
+                df[col] = df[col].apply(
+                    lambda v: json.dumps(v) if isinstance(v, (dict, list)) else v
+                )
+
+        return df
+
+    def get_total_span_count(
+        self,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ) -> int:
+        query = """
+            SELECT COUNT(*) AS count
+            FROM spans s
+            JOIN traces t ON s.trace_rowid = t.id
+            JOIN projects p ON t.project_rowid = p.id
+            WHERE p.name = %s
+        """
+        params: list[Any] = [self.project]
+
+        if start_time is not None:
+            query += " AND s.start_time >= %s"
+            params.append(start_time)
+        if end_time is not None:
+            query += " AND s.start_time < %s"
+            params.append(end_time)
+
+        rows = self._execute_query(query, tuple(params))
+        return int(rows[0]["count"]) if rows else 0
+
+    def get_time_range(self) -> tuple[datetime, datetime]:
+        """Return (min, max) of all span start_times for the project."""
+        query = """
+            SELECT MIN(s.start_time) AS min_time, MAX(s.start_time) AS max_time
+            FROM spans s
+            JOIN traces t ON s.trace_rowid = t.id
+            JOIN projects p ON t.project_rowid = p.id
+            WHERE p.name = %s
+        """
+        rows = self._execute_query(query, (self.project,))
+        if not rows or rows[0]["min_time"] is None:
+            raise ValueError(
+                f"No spans found in project '{self.project}' under schema '{self.schema}'"
+            )
+        return rows[0]["min_time"], rows[0]["max_time"]
+
+    def get_span_annotations_dataframe(
+        self,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ) -> pd.DataFrame:
+        """Fetch span annotations for the project."""
+        query = """
+            SELECT
+                sa.span_rowid,
+                s.span_id,
+                sa.name,
+                sa.label,
+                sa.score,
+                sa.explanation,
+                sa.metadata,
+                sa.annotator_kind,
+                sa.created_at,
+                sa.updated_at
+            FROM span_annotations sa
+            JOIN spans s ON sa.span_rowid = s.id
+            JOIN traces t ON s.trace_rowid = t.id
+            JOIN projects p ON t.project_rowid = p.id
+            WHERE p.name = %s
+        """
+        params: list[Any] = [self.project]
+
+        if start_time is not None:
+            query += " AND sa.created_at >= %s"
+            params.append(start_time)
+        if end_time is not None:
+            query += " AND sa.created_at < %s"
+            params.append(end_time)
+
+        rows = self._execute_query(query, tuple(params))
+        return pd.DataFrame(rows)
+
+    def test_connection(self) -> bool:
+        """Confirm we can reach Postgres and the project exists."""
+        try:
+            rows = self._execute_query(
+                "SELECT id FROM projects WHERE name = %s LIMIT 1", (self.project,)
+            )
+            return len(rows) > 0
+        except PhoenixPostgresError:
+            return False
+
+    def close(self) -> None:
+        """Close the cached connection, if any."""
+        if self._conn is not None and not self._conn.closed:
+            self._conn.close()
+        self._conn = None
+
+    def __enter__(self) -> PhoenixPostgresClient:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        # Mask password in the URL for safe logging
+        safe_url = self.connection_url
+        if "@" in safe_url and "://" in safe_url:
+            scheme, rest = safe_url.split("://", 1)
+            if "@" in rest:
+                creds, host = rest.split("@", 1)
+                if ":" in creds:
+                    user, _ = creds.split(":", 1)
+                    safe_url = f"{scheme}://{user}:***@{host}"
+        return (
+            f"PhoenixPostgresClient(url={safe_url!r}, "
+            f"project={self.project!r}, schema={self.schema!r})"
+        )

--- a/dev_agent_lens/core/sources.py
+++ b/dev_agent_lens/core/sources.py
@@ -41,6 +41,7 @@ class SourceType(str, Enum):
     """Types of trace data sources."""
 
     PHOENIX = "phoenix"
+    PHOENIX_POSTGRES = "phoenix-postgres"
     ARIZE = "arize"
     CLAUDE = "claude"
 
@@ -69,6 +70,10 @@ class SourceConfig:
     project: str | None = None
     sqlite_container: str | None = None  # Docker container name for direct SQLite access
 
+    # Phoenix-Postgres-specific
+    connection_url: str | None = None  # postgres://user:pass@host:port/db
+    schema: str | None = None  # default 'phoenix'
+
     # Arize-specific
     space_key: str | None = None
     model_id: str | None = None
@@ -93,6 +98,13 @@ class SourceConfig:
                 data["project"] = self.project
             if self.sqlite_container:
                 data["sqlite_container"] = self.sqlite_container
+        elif self.source_type == SourceType.PHOENIX_POSTGRES:
+            if self.connection_url:
+                data["connection_url"] = self.connection_url
+            if self.project:
+                data["project"] = self.project
+            if self.schema:
+                data["schema"] = self.schema
         elif self.source_type == SourceType.ARIZE:
             if self.space_key:
                 data["space_key"] = self.space_key
@@ -119,6 +131,8 @@ class SourceConfig:
             url=data.get("url"),
             project=data.get("project"),
             sqlite_container=data.get("sqlite_container"),
+            connection_url=data.get("connection_url"),
+            schema=data.get("schema"),
             space_key=data.get("space_key"),
             model_id=data.get("model_id"),
             claude_dir=data.get("claude_dir"),
@@ -139,6 +153,9 @@ class SourceConfig:
         if self.source_type == SourceType.PHOENIX:
             if not self.url:
                 errors.append("Phoenix source requires 'url'")
+        elif self.source_type == SourceType.PHOENIX_POSTGRES:
+            if not self.connection_url:
+                errors.append("Phoenix-Postgres source requires 'connection_url'")
         elif self.source_type == SourceType.ARIZE:
             if not self.space_key:
                 errors.append("Arize source requires 'space_key'")
@@ -154,6 +171,11 @@ class SourceConfig:
         """Get a human-readable display string."""
         if self.source_type == SourceType.PHOENIX:
             return f"Phoenix @ {self.url or 'localhost:6006'}"
+        elif self.source_type == SourceType.PHOENIX_POSTGRES:
+            host = "?"
+            if self.connection_url and "@" in self.connection_url:
+                host = self.connection_url.rsplit("@", 1)[-1]
+            return f"Phoenix-Postgres @ {host} (schema={self.schema or 'phoenix'})"
         elif self.source_type == SourceType.ARIZE:
             return f"Arize ({self.model_id or 'unknown'})"
         elif self.source_type == SourceType.CLAUDE:
@@ -326,14 +348,31 @@ def create_source_from_env() -> list[SourceConfig]:
     """Create source configurations from environment variables.
 
     This provides backward compatibility with the old env-based configuration.
-    Creates sources based on DAL_PHOENIX_URL and ARIZE_API_KEY.
+    Creates sources based on DAL_PHOENIX_URL, PHOENIX_SQL_DATABASE_URL, and
+    ARIZE_API_KEY.
 
     Returns:
         List of sources created from environment variables.
     """
     sources = []
 
-    # Check for Phoenix
+    # Check for Phoenix-Postgres (preferred when both REST + Postgres are set)
+    pg_url = os.getenv("PHOENIX_SQL_DATABASE_URL")
+    if pg_url:
+        pg_schema = os.getenv("PHOENIX_SQL_DATABASE_SCHEMA", "phoenix")
+        pg_project = os.getenv("DAL_PHOENIX_PROJECT", "dev-agent-lens")
+        sources.append(
+            SourceConfig(
+                name="phoenix-postgres-default",
+                source_type=SourceType.PHOENIX_POSTGRES,
+                connection_url=pg_url,
+                schema=pg_schema,
+                project=pg_project,
+                local_only=False,  # Shared Postgres is shareable
+            )
+        )
+
+    # Check for Phoenix REST
     phoenix_url = os.getenv("DAL_PHOENIX_URL")
     if phoenix_url:
         phoenix_project = os.getenv("DAL_PHOENIX_PROJECT", "default")

--- a/docs/sync-historical.md
+++ b/docs/sync-historical.md
@@ -7,9 +7,17 @@ Pull trace data from Phoenix or Arize into local storage for offline analysis.
 Before syncing, configure a named source:
 
 ```bash
-# For Phoenix (local)
+# For Phoenix (local, REST)
 dal config add-source my-phoenix --type phoenix \
     --url http://localhost:6006 --project default
+
+# For Phoenix on external Postgres (recommended when Phoenix is configured
+# with PHOENIX_SQL_DATABASE_URL — bypasses the REST API and reads straight
+# from the DB. --connection-url and --schema fall back to env vars
+# PHOENIX_SQL_DATABASE_URL / PHOENIX_SQL_DATABASE_SCHEMA, so credentials
+# don't need to live on the command line.)
+dal config add-source my-phoenix-pg --type phoenix-postgres \
+    --project dev-agent-lens --shared
 
 # For Arize (cloud) - requires env vars
 export ARIZE_API_KEY=your-api-key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "openai>=2.13.0",
     "oxenai>=0.42.0",
     "pandas>=2.0.0",
+    "psycopg[binary]>=3.1.0",
     "pyarrow>=22.0.0",
     "python-dotenv>=1.0.0",
 ]

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -376,6 +376,87 @@ class TestConfigCommand:
         assert result.exit_code == 1
         assert "Error" in result.output
 
+    def test_config_add_source_phoenix_postgres_explicit(
+        self, runner, monkeypatch, tmp_path
+    ):
+        """add-source --type phoenix-postgres saves connection_url + schema."""
+        monkeypatch.setenv("DAL_CONFIG_PATH", str(tmp_path / "config"))
+        # Make sure env-var fallback isn't masking missing-flag bugs
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_URL", raising=False)
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
+
+        result = runner.invoke(
+            main,
+            [
+                "config", "add-source", "phoenix-pg",
+                "--type", "phoenix-postgres",
+                "--connection-url", "postgresql://u:p@h:5432/d",
+                "--schema", "phoenix",
+                "--project", "dev-agent-lens",
+                "--shared",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Added source: phoenix-pg" in result.output
+        assert "phoenix-postgres" in result.output
+
+        # Round-trip the saved file
+        from dev_agent_lens.core.sources import SourceManager, SourceType
+
+        saved = SourceManager().get_source("phoenix-pg")
+        assert saved is not None
+        assert saved.source_type == SourceType.PHOENIX_POSTGRES
+        assert saved.connection_url == "postgresql://u:p@h:5432/d"
+        assert saved.schema == "phoenix"
+        assert saved.project == "dev-agent-lens"
+        assert saved.local_only is False
+
+    def test_config_add_source_phoenix_postgres_env_fallback(
+        self, runner, monkeypatch, tmp_path
+    ):
+        """phoenix-postgres falls back to PHOENIX_SQL_DATABASE_URL env var."""
+        monkeypatch.setenv("DAL_CONFIG_PATH", str(tmp_path / "config"))
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_URL", "postgresql://u:p@env:5432/d")
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_SCHEMA", "phoenix_custom")
+
+        result = runner.invoke(
+            main,
+            [
+                "config", "add-source", "phoenix-pg-env",
+                "--type", "phoenix-postgres",
+                "--project", "dev-agent-lens",
+                "--shared",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        from dev_agent_lens.core.sources import SourceManager
+
+        saved = SourceManager().get_source("phoenix-pg-env")
+        assert saved is not None
+        assert saved.connection_url == "postgresql://u:p@env:5432/d"
+        assert saved.schema == "phoenix_custom"
+
+    def test_config_add_source_phoenix_postgres_missing_url(
+        self, runner, monkeypatch, tmp_path
+    ):
+        """phoenix-postgres without connection_url errors out."""
+        monkeypatch.setenv("DAL_CONFIG_PATH", str(tmp_path / "config"))
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_URL", raising=False)
+
+        result = runner.invoke(
+            main,
+            [
+                "config", "add-source", "bad-pg",
+                "--type", "phoenix-postgres",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "connection_url" in result.output
+
     def test_config_list_sources_empty(self, runner, monkeypatch, tmp_path):
         """Config list-sources shows message when no sources."""
         monkeypatch.setenv("DAL_CONFIG_PATH", str(tmp_path / "config"))

--- a/tests/clients/test_phoenix_postgres.py
+++ b/tests/clients/test_phoenix_postgres.py
@@ -1,0 +1,212 @@
+"""
+Tests for PhoenixPostgresClient.
+
+These tests mock psycopg connections so they don't need a live Postgres.
+The goal is to lock in:
+- The query shape (joins, parameters, ordering)
+- JSONB → string serialization for backwards-compat with SQLite client
+- Repr password masking
+- Test_connection / close lifecycle
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from dev_agent_lens.clients.phoenix_postgres import (
+    PhoenixPostgresClient,
+    PhoenixPostgresConnectionError,
+    PhoenixPostgresError,
+    PhoenixPostgresQueryError,
+)
+
+
+@pytest.fixture
+def mock_psycopg(monkeypatch):
+    """Patch psycopg.connect so the client thinks it has a live connection."""
+    fake_psycopg = MagicMock()
+    fake_conn = MagicMock()
+    fake_conn.closed = False
+    fake_psycopg.connect.return_value = fake_conn
+
+    # Make `import psycopg` succeed inside the client module
+    monkeypatch.setitem(__import__("sys").modules, "psycopg", fake_psycopg)
+    # And also psycopg.rows used by _execute_query
+    fake_rows = MagicMock()
+    fake_rows.dict_row = "dict_row_sentinel"
+    monkeypatch.setitem(__import__("sys").modules, "psycopg.rows", fake_rows)
+
+    return fake_psycopg, fake_conn
+
+
+def _make_cursor(rows: list[dict]) -> MagicMock:
+    """Build a MagicMock cursor that yields the given rows."""
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchall.return_value = rows
+    return cur
+
+
+class TestPhoenixPostgresClientLifecycle:
+    """Connection lifecycle, repr, and close behavior."""
+
+    def test_repr_masks_password(self):
+        """The repr must not expose the password from the URL."""
+        client = PhoenixPostgresClient(
+            connection_url="postgresql://user:supersecret@host:5432/db",
+            project="p",
+        )
+        s = repr(client)
+        assert "supersecret" not in s
+        assert "user" in s
+        assert "host:5432/db" in s
+
+    def test_repr_handles_url_without_creds(self):
+        """Repr should not crash if the URL has no creds."""
+        client = PhoenixPostgresClient(
+            connection_url="postgresql://host:5432/db",
+            project="p",
+        )
+        # Just shouldn't raise
+        repr(client)
+
+    def test_init_without_psycopg_raises(self, monkeypatch):
+        """Helpful error if psycopg isn't installed."""
+        # Force the import inside __init__ to fail
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "psycopg":
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        with pytest.raises(PhoenixPostgresError, match="psycopg"):
+            PhoenixPostgresClient(connection_url="postgresql://h/d")
+
+
+class TestPhoenixPostgresClientQueries:
+    """Query shape + result handling."""
+
+    def test_get_total_span_count_filters_by_project(self, mock_psycopg):
+        """Total count query filters by project name."""
+        _, fake_conn = mock_psycopg
+        fake_conn.cursor.return_value = _make_cursor([{"count": 42}])
+
+        client = PhoenixPostgresClient(
+            connection_url="postgresql://u:p@h:5432/d",
+            project="dev-agent-lens",
+            schema="phoenix",
+        )
+        n = client.get_total_span_count()
+
+        assert n == 42
+        # Validate the SQL passed in. The first cursor.execute call sets
+        # search_path; the second one runs the count query.
+        executed_calls = [c for c in fake_conn.cursor().execute.call_args_list]
+        # At least one call must be the COUNT(*) query, parametrized on project
+        count_calls = [
+            c for c in executed_calls
+            if c.args and "COUNT(*)" in str(c.args[0])
+        ]
+        assert count_calls, "expected COUNT(*) query to be executed"
+        assert count_calls[0].args[1][0] == "dev-agent-lens"
+
+    def test_get_spans_dataframe_returns_dataframe(self, mock_psycopg):
+        """get_spans_dataframe returns a DataFrame matching SQLite shape."""
+        _, fake_conn = mock_psycopg
+        rows = [
+            {
+                "context.span_id": "s1",
+                "context.trace_id": "t1",
+                "parent_id": None,
+                "name": "root",
+                "span_kind": "LLM",
+                "start_time": datetime(2026, 5, 6, 12, 0),
+                "end_time": datetime(2026, 5, 6, 12, 0, 5),
+                "status_code": "OK",
+                "status_message": None,
+                "attributes": {"foo": "bar"},
+                "events": [],
+                "cumulative_error_count": 0,
+                "cumulative_llm_token_count_prompt": 100,
+                "cumulative_llm_token_count_completion": 50,
+                "llm_token_count_prompt": 100,
+                "llm_token_count_completion": 50,
+            }
+        ]
+        fake_conn.cursor.return_value = _make_cursor(rows)
+
+        client = PhoenixPostgresClient(
+            connection_url="postgresql://u:p@h:5432/d",
+            project="dev-agent-lens",
+        )
+        df = client.get_spans_dataframe(limit=10)
+
+        assert isinstance(df, pd.DataFrame)
+        assert df.shape == (1, 16)
+        assert "context.span_id" in df.columns
+        assert "context.trace_id" in df.columns
+        # JSONB columns must be serialized to strings for SQLite-client parity
+        assert df["attributes"].iloc[0] == json.dumps({"foo": "bar"})
+        assert df["events"].iloc[0] == json.dumps([])
+
+    def test_get_time_range_raises_on_empty_project(self, mock_psycopg):
+        """Empty project surfaces a clear ValueError."""
+        _, fake_conn = mock_psycopg
+        fake_conn.cursor.return_value = _make_cursor(
+            [{"min_time": None, "max_time": None}]
+        )
+
+        client = PhoenixPostgresClient(
+            connection_url="postgresql://u:p@h:5432/d",
+            project="missing-project",
+        )
+
+        with pytest.raises(ValueError, match="missing-project"):
+            client.get_time_range()
+
+    def test_test_connection_returns_false_on_error(self, mock_psycopg):
+        """test_connection swallows errors and returns False."""
+        _, fake_conn = mock_psycopg
+
+        # Make the cursor raise to simulate a query error
+        bad_cursor = MagicMock()
+        bad_cursor.__enter__ = MagicMock(return_value=bad_cursor)
+        bad_cursor.__exit__ = MagicMock(return_value=False)
+        bad_cursor.execute.side_effect = Exception("boom")
+        fake_conn.cursor.return_value = bad_cursor
+
+        client = PhoenixPostgresClient(
+            connection_url="postgresql://u:p@h:5432/d",
+            project="x",
+        )
+        # Should not raise — test_connection returns False on any failure
+        assert client.test_connection() is False
+
+
+class TestPhoenixPostgresClientContextManager:
+    """Context manager support."""
+
+    def test_context_manager_closes_connection(self, mock_psycopg):
+        """Exiting the with block closes the cached connection."""
+        _, fake_conn = mock_psycopg
+        fake_conn.cursor.return_value = _make_cursor([{"id": 1}])
+
+        with PhoenixPostgresClient(
+            connection_url="postgresql://u:p@h:5432/d",
+            project="x",
+        ) as client:
+            client.test_connection()
+
+        # close() should have been called on the cached connection
+        fake_conn.close.assert_called()

--- a/tests/core/test_sources.py
+++ b/tests/core/test_sources.py
@@ -174,6 +174,80 @@ class TestSourceConfig:
         assert "Arize" in source.get_display_info()
         assert "my-model" in source.get_display_info()
 
+    def test_phoenix_postgres_source_to_dict(self):
+        """Phoenix-Postgres source serializes connection_url and schema."""
+        source = SourceConfig(
+            name="phoenix-pg",
+            source_type=SourceType.PHOENIX_POSTGRES,
+            connection_url="postgresql://u:p@h:5432/d",
+            schema="phoenix",
+            project="dev-agent-lens",
+            local_only=False,
+        )
+
+        result = source.to_dict()
+
+        assert result["type"] == "phoenix-postgres"
+        assert result["connection_url"] == "postgresql://u:p@h:5432/d"
+        assert result["schema"] == "phoenix"
+        assert result["project"] == "dev-agent-lens"
+        assert result["local_only"] is False
+
+    def test_phoenix_postgres_from_dict(self):
+        """Phoenix-Postgres source deserializes correctly."""
+        data = {
+            "type": "phoenix-postgres",
+            "connection_url": "postgresql://u:p@h:5432/d",
+            "schema": "phoenix",
+            "project": "dev-agent-lens",
+            "local_only": False,
+        }
+
+        source = SourceConfig.from_dict("phoenix-pg", data)
+
+        assert source.name == "phoenix-pg"
+        assert source.source_type == SourceType.PHOENIX_POSTGRES
+        assert source.connection_url == "postgresql://u:p@h:5432/d"
+        assert source.schema == "phoenix"
+        assert source.project == "dev-agent-lens"
+        assert source.local_only is False
+
+    def test_validate_phoenix_postgres_missing_connection_url(self):
+        """Phoenix-Postgres source requires a connection_url."""
+        source = SourceConfig(
+            name="phoenix-pg",
+            source_type=SourceType.PHOENIX_POSTGRES,
+        )
+
+        errors = source.validate()
+        assert any("connection_url" in e for e in errors)
+
+    def test_validate_phoenix_postgres_valid(self):
+        """Phoenix-Postgres source with connection_url is valid."""
+        source = SourceConfig(
+            name="phoenix-pg",
+            source_type=SourceType.PHOENIX_POSTGRES,
+            connection_url="postgresql://u:p@h:5432/d",
+        )
+
+        assert source.validate() == []
+
+    def test_get_display_info_phoenix_postgres(self):
+        """Phoenix-Postgres display masks credentials and shows schema."""
+        source = SourceConfig(
+            name="phoenix-pg",
+            source_type=SourceType.PHOENIX_POSTGRES,
+            connection_url="postgresql://user:secret@h.example.com:5432/db",
+            schema="phoenix",
+        )
+
+        info = source.get_display_info()
+        assert "Phoenix-Postgres" in info
+        assert "h.example.com:5432/db" in info
+        assert "schema=phoenix" in info
+        # Password must not leak into the display string
+        assert "secret" not in info
+
 
 class TestSourceManager:
     """Tests for SourceManager class."""


### PR DESCRIPTION
## Summary
- Adds `PhoenixPostgresClient` (clients/phoenix_postgres.py) with same surface as `PhoenixSQLiteClient` so downstream code stays backend-agnostic
- New `SourceType.PHOENIX_POSTGRES` threaded through `core/sources.py`, the lightweight sync path, the checkpoint sync path, and `dal config add-source --type phoenix-postgres`
- Renames the internal `sqlite_client` parameter to `direct_client` since both SQLite and Postgres now share that role
- README + `docs/sync-historical.md` document the new source as the recommended path post-ENG2-817

## Why
Per ENG2-1153 / Adam–Alex sync 2026-05-06: with Phoenix on Supabase Postgres (ENG2-817 ✅), DAL should be able to talk to Postgres directly instead of paying the cost of Phoenix's REST/GraphQL API. This unblocks shared-team workflows (multiple engineers reading from the same trace store) without needing a Phoenix server in front.

## CLI ergonomics
`--connection-url` and `--schema` fall back to `PHOENIX_SQL_DATABASE_URL` and `PHOENIX_SQL_DATABASE_SCHEMA` env vars, so credentials never need to live on the command line:

```bash
# With env vars set in .env:
dal config add-source phoenix-supabase --type phoenix-postgres \
    --project dev-agent-lens --shared

# Or fully explicit:
dal config add-source phoenix-supabase --type phoenix-postgres \
    --connection-url "postgresql://user:pass@host:5432/postgres" \
    --schema phoenix --project dev-agent-lens --shared
```

## Acceptance criteria (from ENG2-1153)
- [x] Schema documented (joins on `spans → traces → projects`, see `phoenix_postgres.py` query bodies)
- [x] New backend client at `dev_agent_lens/clients/phoenix_postgres.py` with connection string from env
- [x] `dal sync` works against the new backend (REST and Postgres now share the lightweight + checkpoint paths)
- [x] Query parity — same column shape (`context.span_id`, `context.trace_id`, `parent_id`, `name`, `span_kind`, `start_time`, `end_time`, `status_code`, `status_message`, `attributes`, `events`, `cumulative_*`, `llm_token_count_*`) so callers using `normalize_phoenix` work without changes
- [x] Documented in README and `docs/sync-historical.md` as the recommended path post-ENG2-817

## Tests
- 8 new client tests (mocked psycopg) for query shape, JSONB→string serialization (parity with SQLite), repr password masking, context manager lifecycle, and connection error paths
- 5 new SourceConfig tests for serialization roundtrip, validation, and display info masking
- 3 new CLI tests for `add-source --type phoenix-postgres` (explicit flags, env-var fallback, missing-url error)

```
$ uv run pytest tests/clients/test_phoenix_postgres.py tests/core/test_sources.py tests/cli/test_main.py::TestConfigCommand
================================ 50 passed in 1.5s ================================
```

(3 pre-existing failures in `test_phoenix_sqlite.py` time-filter tests are unrelated — verified on a clean stash of the branch.)

## Live verification
Verified end-to-end against the real Supabase project:
- `test_connection`: True
- `get_total_span_count`: 327 spans (was 130 at the start of the work; new traces flowing in)
- `get_spans_dataframe(limit=3)`: shape (3, 16), all expected columns present
- `create_source_from_env()` auto-creates `phoenix-postgres-default` source from `PHOENIX_SQL_DATABASE_URL`
- `SourceManager` round-trips the source config to disk

## Test plan
- [x] Pull branch, copy `.env.example` and set `PHOENIX_SQL_DATABASE_URL` to the team's Supabase Session pooler URL
- [x] `uv run dal config add-source phoenix-supabase --type phoenix-postgres --project dev-agent-lens --shared`
- [x] `uv run dal config show` — confirm source is listed under "Named Sources"
- [x] `uv run dal sync --source phoenix-supabase --days 1` — confirm sync runs and lands data in `~/.dal/data/parquet/`

## Notes
- This stays open core: no commercial dependencies, no Teraflop-specific Supabase project IDs hardcoded. Anyone with their own Phoenix-on-Postgres can use this directly.
- Ticket ENG2-1153 stays In Progress on Linear until merge.

Refs ENG2-1153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)