### PR TITLE
fix(docker): pin litellm-oauth-fix image to :multi-arch tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 services:
   # Arize AX LiteLLM proxy (use with --profile arize)
   litellm-proxy:
-    image: aowen14/litellm-oauth-fix:latest
+    image: aowen14/litellm-oauth-fix:multi-arch
     ports:
       - "4000:4000"
     volumes:
@@ -45,7 +45,7 @@ services:
 
   # Phoenix-based LiteLLM proxy (use with --profile phoenix)
   litellm-proxy-phoenix:
-    image: aowen14/litellm-oauth-fix:latest
+    image: aowen14/litellm-oauth-fix:multi-arch
     ports:
       - "4000:4000"
     volumes:
@@ -198,7 +198,7 @@ services:
   # Test container for Arize AX (cloud) - semi-persistent, on-demand
   # Usage: docker compose --profile test-arize up -d litellm-test-arize
   litellm-test-arize:
-    image: aowen14/litellm-oauth-fix:latest
+    image: aowen14/litellm-oauth-fix:multi-arch
     ports:
       - "4100:4000"
     volumes:
@@ -232,7 +232,7 @@ services:
   # Uses the same Phoenix server as dev, but different project name
   # Usage: docker compose --profile test-phoenix up -d litellm-test-phoenix
   litellm-test-phoenix:
-    image: aowen14/litellm-oauth-fix:latest
+    image: aowen14/litellm-oauth-fix:multi-arch
     ports:
       - "4101:4000"
     volumes:


### PR DESCRIPTION
## Summary
- `aowen14/litellm-oauth-fix:latest` on Docker Hub is **linux/arm64 only**. On amd64 hosts, a fresh `docker compose --profile phoenix up -d` crash-loops the litellm-proxy container with `exec docker/prod_entrypoint.sh: exec format error`.
- Switching all four image refs to `:multi-arch` (which ships both amd64 and arm64) unblocks amd64 users with no impact on arm64 users.
- Why this was hidden: previously running containers on the lambda2 box were on `:multi-arch` via an out-of-band manual override that was never checked into the compose file. A routine `docker compose down && up -d` cycle today re-resolved the tag from YAML and surfaced the regression — burned ~30 min of debugging during a parallel-stack cutover.

## Test plan
- [ ] On a linux/amd64 host, fresh clone → `docker compose --profile phoenix up -d` → `docker compose ps` shows `litellm-proxy-phoenix` reaching a non-restarting state (allow ~10s for healthcheck).
- [ ] `curl -fsS http://localhost:4000/health` returns HTTP 200.
- [ ] On a linux/arm64 host (e.g., Apple Silicon dev laptop), same flow still works — confirms `:multi-arch` is a true superset of `:latest` for our use case.
- [ ] No other lines in `docker-compose.yml` changed (diff is 4 lines, all image tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)