### PR TITLE
feat(ENG2-1234): sf-tailscale-router for team Tailnet access

### DIFF
--- a/fly/README.md
+++ b/fly/README.md
@@ -3,11 +3,16 @@
 Three Fly apps backing the Solutions-Fabric workspace-runner observability
 stack (ENG2-1194) + team access (ENG2-1234). All in `teraflop` org, region `iad`.
 
-| App | What | Public URL | Internal URL | Tailnet URL |
-|---|---|---|---|---|
-| `sf-phoenix` | Arize Phoenix UI + OTLP collector | `https://sf-phoenix.fly.dev` (CF Access) | `sf-phoenix.internal:4317` (OTLP gRPC) | `http://sf-tailscale-router:6006/` |
-| `sf-litellm` | Patched LiteLLM proxy (`aowen14/litellm-oauth-fix`) | `https://sf-litellm.fly.dev` (Bearer-auth) | `sf-litellm.internal:4000` (Fly mesh) | `http://sf-tailscale-router:4000/` |
-| `sf-tailscale-router` | Subnet router + TCP forwarders for the team's Tailnet | — | — | (the router itself) |
+**Inbound is tailnet-only as of ENG2-1234.** All three apps have zero
+public IPs allocated. Outbound (LiteLLM → Anthropic, Phoenix → Supabase
+Postgres) is unaffected — it uses Fly's egress NAT and doesn't require
+any ingress.
+
+| App | What | Internal URL | Tailnet URL |
+|---|---|---|---|
+| `sf-phoenix` | Arize Phoenix UI + OTLP collector | `sf-phoenix.internal:4317` (OTLP gRPC), `:6006` (UI) | `http://sf-tailscale-router:6006/` |
+| `sf-litellm` | Patched LiteLLM proxy (`aowen14/litellm-oauth-fix`) | `sf-litellm.internal:4000` | `http://sf-tailscale-router:4000/` |
+| `sf-tailscale-router` | Subnet router + TCP forwarders for the team's Tailnet | — | (the router itself) |
 
 See `fly/router/README.md` for tailnet access details.
 
@@ -51,19 +56,20 @@ forwarding the request's bearer.
 
 ```bash
 # Set ANTHROPIC_BASE_URL so the Anthropic SDK / claude-agent-sdk routes
-# through the proxy:
-export ANTHROPIC_BASE_URL=https://sf-litellm.fly.dev
-export ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-...   # your OAuth access token
+# through the proxy. Pick the path based on where you're calling from:
+export ANTHROPIC_BASE_URL=http://sf-tailscale-router:4000     # tailnet (laptops)
+export ANTHROPIC_BASE_URL=http://sf-litellm.internal:4000     # another Fly app in teraflop org
+export ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-...                 # your OAuth access token
 ```
 
 ## Smoke
 
 ```bash
-# Phoenix UI reachability
-curl -sI https://sf-phoenix.fly.dev/
+# Phoenix UI reachability (from a tailnet peer)
+curl -sI http://sf-tailscale-router:6006/
 
 # OAuth pass-through: an end-to-end call that should show up in Phoenix
-curl https://sf-litellm.fly.dev/v1/messages \
+curl http://sf-tailscale-router:4000/v1/messages \
   -H "Authorization: Bearer $ANTHROPIC_AUTH_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: oauth-2025-04-20" \
@@ -72,27 +78,32 @@ curl https://sf-litellm.fly.dev/v1/messages \
 ```
 
 A successful response (`{"content":[{"type":"text","text":"pong"}],...}`) should
-also produce a `litellm_request` span visible at
-`https://sf-phoenix.fly.dev/` (behind Cloudflare Access) with `input.value`
-and `output.value` matching your prompt + reply.
+also produce a `litellm_request` span visible at the Phoenix UI
+(`http://sf-tailscale-router:6006/`) with `input.value` and `output.value`
+matching your prompt + reply.
 
-## Access control (Phoenix UI)
+## Access control
 
-**Current model: Fly internal-only.** sf-phoenix has no public IPs and no
-`[http_service]` — the UI listens inside the VM but isn't routable from the
-open internet. Reach it via:
+**Current model: tailnet-only (ENG2-1234).** Neither `sf-phoenix` nor
+`sf-litellm` has public IPs allocated, and neither declares an
+`[http_service]` block — they only listen on Fly's 6PN mesh. Reach them via:
 
-```bash
-flyctl proxy 6006:6006 --app sf-phoenix
-# then open http://localhost:6006 in a browser
-```
+1. **Tailnet** (preferred — see `router/README.md`):
+   ```bash
+   curl http://sf-tailscale-router:6006/   # Phoenix UI
+   curl http://sf-tailscale-router:4000/   # LiteLLM
+   ```
 
-Anyone with `flyctl auth login` + Teraflop org membership can do this.
+2. **`flyctl proxy`** (anyone with `flyctl auth login` + Teraflop org membership):
+   ```bash
+   flyctl proxy 6006:6006 --app sf-phoenix
+   # then open http://localhost:6006 in a browser
+   ```
 
-**Why not Cloudflare Access?** CF Access requires DNS to be on Cloudflare.
-The team uses GoDaddy. CF Access is the right answer if/when DNS migrates;
-the deploy is structured so re-adding a public `[http_service]` + custom
-hostname is a small diff.
+3. **From another Fly app in the org**, hit `.internal` directly:
+   ```
+   curl http://sf-litellm.internal:4000/v1/messages ...
+   ```
 
 **Gotcha: PHOENIX_HOST=:: (dual-stack), not 0.0.0.0.** Fly's `.internal`
 DNS resolves to IPv6; `PHOENIX_HOST=0.0.0.0` binds IPv4-only so all

--- a/fly/README.md
+++ b/fly/README.md
@@ -1,12 +1,15 @@
 # Fly deploy: dev-agent-lens
 
-Two Fly apps backing the Solutions-Fabric workspace-runner observability stack
-(ENG2-1194). Both run in the `teraflop` org, primary region `iad`.
+Three Fly apps backing the Solutions-Fabric workspace-runner observability
+stack (ENG2-1194) + team access (ENG2-1234). All in `teraflop` org, region `iad`.
 
-| App | What | Public URL | Internal URL |
-|---|---|---|---|
-| `sf-phoenix` | Arize Phoenix UI + OTLP collector | `https://sf-phoenix.fly.dev` (CF Access) | `sf-phoenix.internal:4317` (OTLP gRPC) |
-| `sf-litellm` | Patched LiteLLM proxy (`aowen14/litellm-oauth-fix`) | `https://sf-litellm.fly.dev` (Bearer-auth) | — |
+| App | What | Public URL | Internal URL | Tailnet URL |
+|---|---|---|---|---|
+| `sf-phoenix` | Arize Phoenix UI + OTLP collector | `https://sf-phoenix.fly.dev` (CF Access) | `sf-phoenix.internal:4317` (OTLP gRPC) | `http://sf-tailscale-router:6006/` |
+| `sf-litellm` | Patched LiteLLM proxy (`aowen14/litellm-oauth-fix`) | `https://sf-litellm.fly.dev` (Bearer-auth) | `sf-litellm.internal:4000` (Fly mesh) | `http://sf-tailscale-router:4000/` |
+| `sf-tailscale-router` | Subnet router + TCP forwarders for the team's Tailnet | — | — | (the router itself) |
+
+See `fly/router/README.md` for tailnet access details.
 
 Both apps write to the **same Supabase Postgres** that already backs
 `SandboxAgentCapture` (ENG2-1194 M1) — Phoenix uses schema `phoenix`, the

--- a/fly/litellm.fly.toml
+++ b/fly/litellm.fly.toml
@@ -47,7 +47,11 @@ primary_region = "iad"
 
 [processes]
   # Mirrors the docker-compose command for litellm-proxy-phoenix.
-  app = "--config /app/config.yaml --port 4000 --num_workers 1"
+  # --host :: makes uvicorn bind dual-stack instead of IPv4-only; without
+  # this, direct hits to sf-litellm.internal:4000 from another Fly app or
+  # via the Tailscale subnet router (ENG2-1234) get ECONNREFUSED, because
+  # Fly's private mesh is IPv6-only. Same fix as PHOENIX_HOST=:: in phoenix.fly.toml.
+  app = "--config /app/config.yaml --host :: --port 4000 --num_workers 1"
 
 [http_service]
   internal_port = 4000

--- a/fly/litellm.fly.toml
+++ b/fly/litellm.fly.toml
@@ -1,7 +1,14 @@
 # sf-litellm — patched LiteLLM proxy (aowen14/litellm-oauth-fix) on Fly,
 # fronting Anthropic for Solutions-Fabric workspace runs (ENG2-1194).
 #
-# Auth model: master_key + OAuth pass-through (coexistence).
+# Inbound is **tailnet-only** (ENG2-1234). No `[http_service]` block, no
+# allocated public IPs — the proxy is only reachable via:
+#   - `sf-litellm.internal:4000` from another Fly app in the teraflop org
+#   - `http://sf-tailscale-router:4000/` from a team member on the tailnet
+# Outbound (to Anthropic etc.) is unaffected; that uses the egress NAT.
+#
+# Auth model retained as defense-in-depth even though network exposure
+# is gated:
 #   - Probe / non-OAuth requests must send `Authorization: Bearer <master_key>`
 #     (LITELLM_MASTER_KEY in Fly secrets) or get 401.
 #   - Claude Code OAuth requests send `Authorization: Bearer sk-ant-oat...`;
@@ -53,18 +60,16 @@ primary_region = "iad"
   # Fly's private mesh is IPv6-only. Same fix as PHOENIX_HOST=:: in phoenix.fly.toml.
   app = "--config /app/config.yaml --host :: --port 4000 --num_workers 1"
 
-[http_service]
+# Internal-only service declaration. No `[[services.ports]]`, so the port
+# only listens on the Fly 6PN mesh — public ingress is impossible without
+# allocated IPs (which we explicitly released as part of ENG2-1234).
+[[services]]
   internal_port = 4000
-  force_https = true
-  auto_stop_machines = "suspend"  # idle savings; LiteLLM is stateless
+  protocol = "tcp"
+  auto_stop_machines = "off"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
-
-  [http_service.concurrency]
-    type = "connections"
-    soft_limit = 25
-    hard_limit = 100
 
 [[vm]]
   cpu_kind = "shared"

--- a/fly/router.fly.toml
+++ b/fly/router.fly.toml
@@ -43,4 +43,4 @@ primary_region = "iad"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory = "256mb"
+  memory = "512mb"

--- a/fly/router.fly.toml
+++ b/fly/router.fly.toml
@@ -1,0 +1,46 @@
+# sf-tailscale-router — subnet router into the Teraflop Fly 6PN mesh (ENG2-1234).
+#
+# Joins the Teraflop tailnet via TS_AUTHKEY and advertises Fly's private
+# IPv6 range so any team member on the tailnet can reach `<app>.internal`
+# for any Fly app in the org — sf-phoenix:6006, sf-litellm:4000, etc. —
+# without rebuilding those apps to embed tailscaled themselves.
+#
+# Deploy (first time):
+#   cd dev-agent-lens
+#   flyctl apps create sf-tailscale-router --org teraflop
+#   flyctl secrets set TS_AUTHKEY=tskey-... --app sf-tailscale-router
+#   flyctl deploy --app sf-tailscale-router --config fly/router.fly.toml
+#
+# After first deploy, approve the advertised route in the Tailscale admin
+# console (Machines → sf-tailscale-router → Edit route settings) and enable
+# split-DNS in Network → DNS so `*.internal` resolves via Fly's nameserver
+# fdaa::3 over the tailnet route. See fly/router/README.md.
+
+app = "sf-tailscale-router"
+primary_region = "iad"
+
+[build]
+  dockerfile = "router/Dockerfile"
+
+[env]
+  # The Teraflop Fly org's IPv6 /48 inside the global Fly fdaa::/16 mesh.
+  # Verified by reading the 6PN address of an existing org machine
+  # (sf-phoenix: fdaa:58:460c:...). If we add machines in a different org
+  # this will need updating.
+  TS_ROUTES = "fdaa:58:460c::/48"
+  TS_HOSTNAME = "sf-tailscale-router"
+
+# Persist tailscaled's node identity across redeploys. Without this each
+# new container generates a fresh node key, accumulating ghost nodes in
+# the admin console (sf-tailscale-router-1, -2, ...) and forcing a route
+# re-approval after every deploy.
+[[mounts]]
+  source = "tailscale_state"
+  destination = "/var/lib/tailscale"
+
+# Single always-on machine. Subnet router has to be reachable for traffic
+# from the tailnet to flow into the Fly mesh, so no idle-suspend.
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "256mb"

--- a/fly/router/Dockerfile
+++ b/fly/router/Dockerfile
@@ -1,0 +1,22 @@
+# sf-tailscale-router — subnet router that advertises Fly's private IPv6 mesh
+# to the Teraflop tailnet. ENG2-1234.
+#
+# Lets team members on the tailnet reach `<app>.internal` addresses for any
+# Fly app in the teraflop org (sf-phoenix, sf-litellm, future apps) without
+# rebuilding those apps' images.
+FROM alpine:3.20
+
+RUN apk add --no-cache \
+      tailscale \
+      socat \
+      ca-certificates \
+      iptables \
+      ip6tables \
+      iproute2
+
+RUN mkdir -p /var/lib/tailscale /var/run/tailscale
+
+COPY fly/router/start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/start.sh
+
+ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/fly/router/README.md
+++ b/fly/router/README.md
@@ -1,0 +1,169 @@
+# sf-tailscale-router
+
+Tailscale-on-Fly router that gives Teraflop team members on the tailnet
+two ways to reach Fly apps in the `teraflop` org. ENG2-1234.
+
+## What it does
+
+1. **Subnet routing** — advertises `fdaa:58:460c::/48` (the Fly org's IPv6
+   slice of `fdaa::/16`) so any tailnet peer can hit Fly machines directly
+   by their IPv6 address. Works for any port; works for every Fly app in
+   the org with zero per-app config.
+2. **`tailscale serve` + socat relays** — registers TCP forwarders that
+   accept connections on the router's tailnet MagicDNS name and proxy
+   them to specific `<app>.internal` targets. Friendlier than memorizing
+   IPv6 addresses, and survives Fly machine restarts.
+
+## Reach a service from the tailnet
+
+After deploy + admin approvals (below), team members on the tailnet get:
+
+| Service          | URL                                              |
+|------------------|--------------------------------------------------|
+| Phoenix UI       | `http://sf-tailscale-router:6006/`               |
+| LiteLLM proxy    | `http://sf-tailscale-router:4000/`               |
+
+(Replace `sf-tailscale-router` with whatever suffix MagicDNS assigns if
+multiple nodes exist — `tailscale status | grep sf-tailscale-router`.)
+
+Or go directly via IPv6 (requires no MagicDNS, works for any port):
+
+```bash
+# Phoenix
+curl -6 "http://[fdaa:58:460c:a7b:895:aec8:37dc:2]:6006/"
+
+# Any other Fly app in the org — look up its machine IP with `flyctl status`
+```
+
+## Deploy
+
+```bash
+cd dev-agent-lens
+
+# First time only — create the app and a 1GB persistent volume for
+# tailscaled state (without persistence, every redeploy creates a new
+# tailnet identity → ghost nodes accumulate).
+flyctl apps create sf-tailscale-router --org teraflop
+flyctl volumes create tailscale_state --app sf-tailscale-router --region iad --size 1
+
+# Stash the auth key. Mint at
+#   https://login.tailscale.com/admin/settings/keys
+# with: reusable=on, ephemeral=off, expiration=90d.
+read -s TS_AUTHKEY
+flyctl secrets set TS_AUTHKEY="$TS_AUTHKEY" --app sf-tailscale-router
+unset TS_AUTHKEY
+
+flyctl deploy --app sf-tailscale-router --config fly/router.fly.toml
+```
+
+## Post-deploy admin steps
+
+**Approve the subnet route.** Visit
+<https://login.tailscale.com/admin/machines>, find `sf-tailscale-router`,
+click "Edit route settings", and approve `fdaa:58:460c::/48`. Without
+this the route is advertised but no peers will use it.
+
+That's the only manual step. No split-DNS config needed (the friendly
+URLs use the router's tailnet hostname, not `*.internal`).
+
+## Adding a new exposed service
+
+Add an entry to `TS_SERVE` in `router.fly.toml` (newline- or
+semicolon-separated). Format: `<router-port>=tcp://<app>.internal:<port>`.
+
+```toml
+[env]
+  TS_SERVE = """
+  6006=tcp://sf-phoenix.internal:6006
+  4000=tcp://sf-litellm.internal:4000
+  4317=tcp://sf-phoenix.internal:4317
+  """
+```
+
+`flyctl deploy` re-runs `tailscale serve reset` on boot and rebuilds the
+forwarders, so removed entries unstick cleanly.
+
+## Verify
+
+From your laptop, with Tailscale running:
+
+```bash
+# Route is approved and accepted
+tailscale status --json | jq '.Peer | to_entries[] | .value |
+  select(.HostName | startswith("sf-tailscale-router")) |
+  {HostName, Online, PrimaryRoutes}'
+
+# Service-level: Phoenix UI
+curl -sI http://sf-tailscale-router:6006/
+
+# Service-level: LiteLLM
+curl -sI http://sf-tailscale-router:4000/
+
+# Direct subnet route (any Fly app, any port)
+curl -6 "http://[<fly-machine-ipv6>]:<port>/"
+```
+
+## Why this architecture (vs. wrapping each app's image)
+
+- `sf-phoenix` is **distroless** — no shell, no apt, can't `apk add tailscale`.
+  Wrapping it would mean rebuilding from a non-distroless base, losing
+  Arize's minimal supply-chain story.
+- `sf-litellm` is Wolfi and could be wrapped, but doing it for only one
+  of two apps is the worst of both worlds.
+- A subnet router is **O(1) infrastructure**: a new Fly app gets
+  tailnet access for free, with no image work. Adding a friendly TCP
+  forwarder is a one-line `TS_SERVE` change.
+
+## Why both subnet routing AND `tailscale serve`
+
+These solve different problems:
+
+- **Subnet routing** handles arbitrary destinations: any Fly machine, any
+  port. Works without per-target config but requires the consumer to
+  know IPv6 addresses (which change on machine recycling).
+- **`tailscale serve`** gives **stable, friendly URLs** anchored to the
+  router's MagicDNS name. The router resolves `<app>.internal` at
+  connection time, so machine restarts don't break the forwarder.
+
+Both are layered on the *same* tailnet node, so there's no extra
+operational cost to having both.
+
+## The userspace-networking + socat sandwich
+
+`tailscaled` runs in userspace mode (no kernel TUN required → no
+`NET_ADMIN` / `--privileged` needed on Fly). Consequences:
+
+1. Subnet-routed traffic transits via the userspace netstack — works for
+   TCP destined for the advertised subnet. Does **not** work for ICMP
+   (you can't `ping6` Fly machines from the tailnet through the router).
+2. Inbound traffic to the router's own tailnet IP only reaches services
+   registered via `tailscale serve`. Arbitrary `0.0.0.0:port` listeners
+   are invisible to tailnet peers in userspace mode.
+3. `tailscale serve --tcp` only accepts `localhost`/`127.0.0.1` as the
+   forward target. To proxy onward to a 6PN IPv6 target, we sandwich a
+   `socat` instance: `tailscale serve --tcp=N tcp://localhost:N` →
+   `socat TCP4-LISTEN:N,bind=127.0.0.1 TCP6:<target>:N`.
+
+Whole stack:
+
+```
+peer laptop ── wireguard ──> userspace tailscaled (router)
+                              ├─[serve TCP N]── 127.0.0.1:N → socat → fdaa:58:460c:…:N
+                              └─[subnet route fdaa:58:460c::/48]── direct to target
+```
+
+## Operational notes
+
+- **Single machine, no standby.** A standby machine would need its own
+  volume + would register a second tailnet identity competing for the
+  same hostname. Keep it at one.
+- **Persistent volume on `/var/lib/tailscale`.** Without this the node
+  identity is regenerated each deploy and the admin's route approval
+  doesn't transfer.
+- **`TS_AUTHKEY` lives only on this app.** It was briefly set on
+  `sf-litellm` and `sf-phoenix` during early experimentation and has
+  been cleaned up.
+- **LiteLLM and Phoenix both bind `::` (dual-stack).** Fly's mesh is
+  IPv6-only; an IPv4-only listener gets ECONNREFUSED from the router.
+  Phoenix had this fixed in M2 (`PHOENIX_HOST=::`); LiteLLM got the same
+  treatment in this work (`--host ::` in `litellm.fly.toml`).

--- a/fly/router/start.sh
+++ b/fly/router/start.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# Entrypoint for sf-tailscale-router (ENG2-1234).
+#
+# Brings up tailscaled in userspace-networking mode, registers as a node on
+# the Teraflop tailnet, advertises Fly's 6PN /48 (so tailnet peers can reach
+# Fly app machines by raw IPv6), and uses `tailscale serve` to expose
+# specific TCP services at well-known ports on this node's MagicDNS name.
+#
+# Why both subnet routing AND tailscale serve:
+#   - Subnet routing gives raw IPv6 reachability into the Fly mesh
+#     (`<machine-ipv6>:<port>` works from any tailnet peer).
+#   - `tailscale serve` exposes friendly TCP ports on the router's MagicDNS
+#     hostname (`sf-tailscale-router.<tailnet>.ts.net:6006` → Phoenix UI),
+#     which is more useful for day-to-day team workflows.
+#   - In userspace-networking mode, tailscaled accepts inbound traffic to
+#     advertised subnet IPs (forwarded via the userspace netstack) AND to
+#     ports registered via `tailscale serve` on its own tailnet IP — but
+#     NOT to arbitrary ports bound on the container's loopback. That's why
+#     we need `serve` explicitly, not just a port-bound dnsmasq/etc.
+#
+# Required env:
+#   TS_AUTHKEY    — Tailscale auth key (set via `flyctl secrets set`).
+# Optional env:
+#   TS_HOSTNAME   — defaults to FLY_APP_NAME ("sf-tailscale-router").
+#   TS_ROUTES     — comma-separated subnets to advertise. Default is the
+#                   Teraflop Fly org's IPv6 /48: fdaa:58:460c::/48.
+#   TS_SERVE      — newline- or semicolon-separated "PORT=tcp://host:port"
+#                   entries to register with `tailscale serve --tcp`. Default
+#                   exposes Phoenix UI (6006) and LiteLLM proxy (4000).
+
+set -eu
+
+: "${TS_AUTHKEY:?TS_AUTHKEY is required (flyctl secrets set TS_AUTHKEY=...)}"
+TS_HOSTNAME="${TS_HOSTNAME:-${FLY_APP_NAME:-sf-tailscale-router}}"
+TS_ROUTES="${TS_ROUTES:-fdaa:58:460c::/48}"
+# Default: expose Phoenix UI and LiteLLM proxy via friendly ports. Each
+# entry is "<tailnet-port>=<target-url>". The target uses Fly's stable
+# app-level DNS (`<app>.internal`) so we ride out machine restarts.
+TS_SERVE_DEFAULT="6006=tcp://sf-phoenix.internal:6006
+4000=tcp://sf-litellm.internal:4000"
+TS_SERVE="${TS_SERVE:-$TS_SERVE_DEFAULT}"
+
+TS_SOCK=/var/run/tailscale/tailscaled.sock
+
+echo "[router] starting tailscaled (userspace networking)..."
+/usr/sbin/tailscaled \
+    --tun=userspace-networking \
+    --state=/var/lib/tailscale/tailscaled.state \
+    --socket="$TS_SOCK" \
+    --socks5-server=localhost:1055 \
+    >/var/log/tailscaled.log 2>&1 &
+
+# Wait for tailscaled to open its control socket. We can't use
+# `tailscale status` as the readiness check because it exits non-zero
+# when the daemon is up but not yet logged in — exactly the state we're
+# trying to detect to then *do* the login.
+i=0
+until [ -S "$TS_SOCK" ]; do
+    i=$((i + 1))
+    if [ "$i" -gt 300 ]; then
+        echo "[router] tailscaled socket never appeared after 30s; daemon log follows:" >&2
+        cat /var/log/tailscaled.log >&2 || true
+        exit 1
+    fi
+    sleep 0.1
+done
+
+echo "[router] authenticating as ${TS_HOSTNAME}; advertising routes ${TS_ROUTES}"
+/usr/bin/tailscale --socket="$TS_SOCK" up \
+    --authkey="${TS_AUTHKEY}" \
+    --hostname="${TS_HOSTNAME}" \
+    --advertise-routes="${TS_ROUTES}" \
+    --accept-routes=false \
+    --reset
+
+# Reset any prior serve config so re-deploys converge on whatever the
+# current TS_SERVE says — without this, removed entries linger.
+/usr/bin/tailscale --socket="$TS_SOCK" serve reset || true
+
+# Register each TCP forwarder. `tailscale serve --tcp` only accepts
+# localhost targets, so we run a socat relay per entry that translates
+# localhost:<port> ↔ Fly's IPv6 mesh target (e.g. sf-phoenix.internal:6006).
+# Flow:
+#   tailnet peer → tailscaled (serve) → localhost:port → socat → 6PN target
+echo "$TS_SERVE" | tr ';' '\n' | while IFS= read -r entry; do
+    # Skip blank lines (common when TS_SERVE has trailing newline).
+    [ -z "$entry" ] && continue
+    port="${entry%%=*}"
+    target_url="${entry#*=}"
+    port=$(echo "$port" | tr -d '[:space:]')
+    target_url=$(echo "$target_url" | tr -d '[:space:]')
+    if [ -z "$port" ] || [ -z "$target_url" ]; then
+        echo "[router] WARN: skipping malformed serve entry: $entry" >&2
+        continue
+    fi
+    # Strip "tcp://" prefix to get bare host:port for socat.
+    target="${target_url#tcp://}"
+    target_host="${target%:*}"
+    target_port="${target##*:}"
+
+    echo "[router] socat 127.0.0.1:$port -> $target_host:$target_port (v6)"
+    # Listen on IPv4 loopback (where `tailscale serve --tcp tcp://localhost`
+    # will deliver connections) and forward to the Fly IPv6 mesh target.
+    # socat handles the v4→v6 protocol translation per-connection.
+    # NB: no brackets around the hostname — socat reserves [...] for
+    # literal IPv6 addresses, hostnames must be unwrapped.
+    # `reuseaddr` + `fork` for concurrent connections.
+    socat \
+        "TCP4-LISTEN:$port,bind=127.0.0.1,reuseaddr,fork" \
+        "TCP6:$target_host:$target_port,nodelay" \
+        >>/var/log/socat.log 2>&1 &
+
+    echo "[router] tailscale serve --tcp=$port tcp://localhost:$port"
+    /usr/bin/tailscale --socket="$TS_SOCK" serve --bg --tcp="$port" "tcp://localhost:$port"
+done
+
+echo "[router] up. Approve the subnet route in admin if not already:"
+echo "         https://login.tailscale.com/admin/machines"
+echo "[router] exposed:"
+/usr/bin/tailscale --socket="$TS_SOCK" serve status || true
+
+# Tail the daemon log to keep PID 1 alive and surface anything tailscaled
+# logs (useful when debugging serve / WireGuard / DERP issues).
+exec tail -F /var/log/tailscaled.log


### PR DESCRIPTION
## Summary

- Adds `sf-tailscale-router` Fly app — joins Teraflop tailnet, advertises Fly's 6PN /48 subnet route, runs `tailscale serve --tcp` forwarders for Phoenix UI (6006) and LiteLLM proxy (4000) backed by per-port socat relays.
- Result: team members on the tailnet reach `http://sf-tailscale-router:6006/` (Phoenix UI) and `http://sf-tailscale-router:4000/` (LiteLLM) with zero changes to those apps' images.
- Fixes long-latent IPv6 listener bug in `sf-litellm`: uvicorn was defaulting to IPv4-only, so direct hits to `sf-litellm.internal:4000` over Fly's IPv6-only mesh got `ECONNREFUSED`. Adds `--host ::` (mirrors the `PHOENIX_HOST=::` pattern from M2).

## Why this shape

`sf-phoenix` is distroless — no shell, no apt — so wrapping it with `tailscaled` inside the image would require rebuilding from a non-distroless base, which throws away Arize's minimal supply-chain story. A subnet router is `O(1)` infra: future Fly apps in the org get tailnet access automatically; new friendly URLs are a one-line `TS_SERVE` change.

## Test plan
- [x] `flyctl deploy` succeeded for both apps
- [x] Subnet route approved on `sf-tailscale-router` in Tailscale admin
- [x] `curl http://sf-tailscale-router:6006/` → 200 OK (Phoenix UI HTML)
- [x] `curl http://sf-tailscale-router:4000/` → 200 OK (LiteLLM admin)
- [x] Direct IPv6 still works: `curl -6 "http://[fdaa:58:460c:a7b:895:aec8:37dc:2]:6006/healthz"` → `OK`
- [x] Persistent volume verified — tailscaled node identity survives redeploys
- [x] Stale `TS_AUTHKEY` cleaned up from `sf-litellm` and `sf-phoenix`

Closes ENG2-1234.