### PR TITLE
feat(fabric): span→conversation reconstruction + session mining tooling (ENG2-1313)

### DIFF
--- a/dev_agent_lens/cli/main.py
+++ b/dev_agent_lens/cli/main.py
@@ -2661,6 +2661,147 @@ def session_context(session_id: str, output: str) -> None:
         click.echo(click.style(f"Error: {e}", fg="red"))
 
 
+@main.command("reconstruct-session")
+@click.argument("session_id")
+@click.option("--source", default=None, help="Parquet source (default: search all sources)")
+@click.option(
+    "--output", "-o", type=click.Path(), default=None,
+    help="Write markdown here (default: stdout)",
+)
+def reconstruct_session_cmd(session_id: str, source: str | None, output: str | None) -> None:
+    """Reconstruct a session's conversation to markdown, in start_time order.
+
+    Examples:
+
+        dal reconstruct-session abc123 --source phoenix-local-alex -o session.md
+
+        dal reconstruct-session abc123
+    """
+    from pathlib import Path
+
+    from dev_agent_lens.fabric.queries import reconstruct_session
+
+    try:
+        export = reconstruct_session(session_id, source=source)
+        if export is None:
+            click.echo(click.style(f"Session '{session_id}' not found.", fg="yellow"))
+            return
+        content = export.main_content
+        if output:
+            Path(output).write_text(content, encoding="utf-8")
+            click.echo(click.style(f"Wrote {len(content):,} chars → {output}", fg="green"))
+        else:
+            click.echo(content)
+    except Exception as e:
+        click.echo(click.style(f"Error: {e}", fg="red"))
+
+
+@main.command("list-sessions")
+@click.option("--source", default=None, help="Parquet source (default: all sources)")
+@click.option("--pattern", default=None, help="Substring/regex to match in span content")
+@click.option(
+    "--tools", default=None,
+    help="Comma-separated tool names; keep sessions referencing ALL of them",
+)
+@click.option("--since", default=None, help="ISO date/datetime lower bound (start_time)")
+@click.option("--until", default=None, help="ISO date/datetime upper bound")
+@click.option("--min-spans", type=int, default=0, help="Drop sessions with fewer than N spans")
+@click.option("--output", type=click.Choice(["text", "json"]), default="text")
+def list_sessions_cmd(
+    source: str | None,
+    pattern: str | None,
+    tools: str | None,
+    since: str | None,
+    until: str | None,
+    min_spans: int,
+    output: str,
+) -> None:
+    """List sessions matching pattern + tool + date filters (newest first).
+
+    Examples:
+
+        dal list-sessions --source phoenix-local-alex --pattern transcript --min-spans 50
+
+        dal list-sessions --tools 'mcp__claude_ai_Linear' --since 2026-05-01 --output json
+    """
+    import json as json_lib
+
+    from dev_agent_lens.fabric.queries import list_sessions
+
+    tool_list = [t.strip() for t in tools.split(",") if t.strip()] if tools else None
+    try:
+        sessions = list_sessions(
+            source=source, pattern=pattern, tools=tool_list,
+            since=since, until=until, min_spans=min_spans,
+        )
+        rows = [
+            {
+                "session_id": s.get("session_id"),
+                "span_count": s.get("span_count", len(s.get("spans", []))),
+                "start_time": s.get("start_time"),
+            }
+            for s in sessions
+        ]
+        if output == "json":
+            click.echo(json_lib.dumps(rows, indent=2, default=str))
+        else:
+            click.echo(click.style(f"{len(rows)} session(s)", fg="green"))
+            for r in rows[:50]:
+                click.echo(f"  {r['session_id']}  {r['span_count']} spans  {r['start_time'] or ''}")
+            if len(rows) > 50:
+                click.echo(f"  ... and {len(rows) - 50} more")
+    except Exception as e:
+        click.echo(click.style(f"Error: {e}", fg="red"))
+
+
+@main.command("export-conversations")
+@click.option("--source", default=None, help="Parquet source (default: all sources)")
+@click.option("--filter", "filter_", default=None, help="Substring/regex to match in span content")
+@click.option("--pattern", default=None, help="Alias for --filter")
+@click.option(
+    "--tools", default=None,
+    help="Comma-separated tool names; keep sessions referencing ALL",
+)
+@click.option("--since", default=None, help="ISO date/datetime lower bound")
+@click.option("--min-spans", type=int, default=0, help="Drop sessions with fewer than N spans")
+@click.option("--limit", type=int, default=None, help="Max sessions to export")
+@click.option(
+    "--output", "-o", type=click.Path(), default=".",
+    help="Output directory (one .md per session)",
+)
+def export_conversations_cmd(
+    source: str | None,
+    filter_: str | None,
+    pattern: str | None,
+    tools: str | None,
+    since: str | None,
+    min_spans: int,
+    limit: int | None,
+    output: str,
+) -> None:
+    """Bulk-export matching sessions to one markdown file per session (written atomically).
+
+    Examples:
+
+        dal export-conversations --source phoenix-lambda2-dal --filter transcript --limit 20
+    """
+    from dev_agent_lens.fabric.queries import export_conversations
+
+    tool_list = [t.strip() for t in tools.split(",") if t.strip()] if tools else None
+    try:
+        written = export_conversations(
+            source=source, filter=filter_ or pattern, tools=tool_list,
+            since=since, limit=limit, output_dir=output, min_spans=min_spans,
+        )
+        click.echo(click.style(f"Wrote {len(written)} session(s) → {output}", fg="green"))
+        for p in written[:20]:
+            click.echo(f"  {p}")
+        if len(written) > 20:
+            click.echo(f"  ... and {len(written) - 20} more")
+    except Exception as e:
+        click.echo(click.style(f"Error: {e}", fg="red"))
+
+
 @main.command("cost")
 @click.argument("entity_type", type=click.Choice(["meeting", "ticket", "project"]))
 @click.argument("entity_id")

--- a/dev_agent_lens/fabric/__init__.py
+++ b/dev_agent_lens/fabric/__init__.py
@@ -1,0 +1,30 @@
+"""Fabric convenience layer over DAL span data (ENG2-1313).
+
+One-call "readable conversation per session, filtered by signal":
+
+    from dev_agent_lens.fabric import (
+        reconstruct_session,   # session_id → markdown export, in time order
+        list_sessions,         # filters → session dicts (newest first)
+        export_conversations,  # bulk write one .md per session, atomically
+    )
+"""
+
+from dev_agent_lens.fabric.queries import (
+    SessionContext,
+    export_conversations,
+    get_meeting_sessions,
+    get_session_context,
+    get_ticket_sessions,
+    list_sessions,
+    reconstruct_session,
+)
+
+__all__ = [
+    "SessionContext",
+    "export_conversations",
+    "get_meeting_sessions",
+    "get_session_context",
+    "get_ticket_sessions",
+    "list_sessions",
+    "reconstruct_session",
+]

--- a/dev_agent_lens/fabric/queries.py
+++ b/dev_agent_lens/fabric/queries.py
@@ -1,0 +1,321 @@
+"""Fabric convenience layer over DAL span data (ENG2-1313).
+
+"Give me a readable conversation per session, filtered by signal" as one call —
+so IR-eval / M12 / future eval mining stops re-hand-rolling DuckDB + per-session
+stitching. Everything here is a THIN wrapper over the existing infra:
+
+    query.query_sessions()                  → parquet-backed session dicts
+    analysis.chains.get_chain_for_session() → spans → linked ConversationChain
+    export.markdown_litellm.export_chain_to_unified_markdown() → chain → markdown
+
+This module also backs the ``dal meeting-sessions`` / ``ticket-sessions`` /
+``session-context`` CLI commands, which import from here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Linear-style ticket ids (ENG2-123, CWORK-456) — specific enough to run over any text.
+_TICKET_RE = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+# Meeting ids are UUIDs. Match only over conversation CONTENT (not raw span attributes),
+# else every trace_id / span_id becomes a false-positive "meeting".
+_UUID_RE = re.compile(
+    r"\b([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\b"
+)
+
+
+def _content_text(spans: list[dict[str, Any]]) -> str:
+    """The conversation content of a session (input+output values) — for entity extraction."""
+    parts: list[str] = []
+    for span in spans:
+        for key in ("input_value", "output_value"):
+            v = span.get(key)
+            if isinstance(v, str) and v:
+                parts.append(v)
+    return "\n".join(parts)
+
+
+def _full_text(spans: list[dict[str, Any]]) -> str:
+    """Content plus raw attributes — for tool-name matching (tool ids can live in attrs)."""
+    parts = [_content_text(spans)]
+    for span in spans:
+        raw = span.get("raw_attributes_json") or span.get("attributes")
+        if isinstance(raw, str) and raw:
+            parts.append(raw)
+    return "\n".join(parts)
+
+
+def _sources() -> list[str]:
+    """All parquet source names under the DAL storage dir."""
+    from dev_agent_lens.query.parquet_query import find_parquet_files
+
+    found = find_parquet_files()
+    return list(found.keys()) if found else []
+
+
+def _query(
+    search: str | None = None,
+    session_id: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    source: str | None = None,
+) -> list[dict[str, Any]]:
+    """query_sessions() over one source, or ALL sources aggregated when source is None.
+
+    query_sessions() returns nothing for a bare search/list with no source, so the
+    convenience layer fans out across every source itself.
+    """
+    from dev_agent_lens.query.query import query_sessions
+
+    kw = dict(search=search, session_id=session_id, start_time=since, end_time=until)
+    if source is not None:
+        return query_sessions(source=source, **kw)
+    out: list[dict[str, Any]] = []
+    for src in _sources():
+        out.extend(query_sessions(source=src, **kw))
+    return out
+
+
+# ── listing ───────────────────────────────────────────────────────────────────
+def list_sessions(
+    source: str | None = None,
+    pattern: str | None = None,
+    tools: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    min_spans: int = 0,
+    session_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """List sessions matching filters, newest-first.
+
+    Wraps :func:`query.query_sessions` (parquet-backed pattern/date/source filters)
+    then applies the ``tools`` + ``min_spans`` predicates the query layer doesn't cover.
+
+    Args:
+        source: parquet source name (e.g. ``phoenix-local-alex``); ``None`` = all sources.
+        pattern: substring/regex to match in span content.
+        tools: keep only sessions whose spans reference ALL of these tool names.
+        since / until: ISO date/datetime bounds (string-compared against span start_time).
+        min_spans: drop sessions with fewer than this many spans.
+        session_id: restrict to a single session id.
+
+    Returns:
+        List of session dicts: ``{session_id, spans, span_count, start_time, end_time}``.
+
+    Example:
+        >>> list_sessions(source="phoenix-local-alex", pattern="transcript", min_spans=50)
+        [{'session_id': '...', 'span_count': 123, 'start_time': '2026-05-…', ...}, ...]
+    """
+    sessions = _query(
+        search=pattern,
+        session_id=session_id,
+        since=since,
+        until=until,
+        source=source,
+    )
+
+    if min_spans:
+        sessions = [
+            s
+            for s in sessions
+            if s.get("span_count", len(s.get("spans", []))) >= min_spans
+        ]
+    if tools:
+        sessions = [s for s in sessions if _matches_all_tools(s.get("spans", []), tools)]
+
+    sessions.sort(key=lambda s: s.get("start_time") or "", reverse=True)
+    return sessions
+
+
+def _matches_all_tools(spans: list[dict[str, Any]], tools: list[str]) -> bool:
+    text = _full_text(spans)
+    return all(tool in text for tool in tools)
+
+
+# ── reconstruction ──────────────────────────────────────────────────────────────
+def reconstruct_session(session_id: str, source: str | None = None):
+    """Reconstruct a single session's conversation to markdown, in start_time order.
+
+    Returns the export object whose ``.main_content`` is the readable markdown (plus
+    ``.subagent_files`` / ``.tool_result_files`` ancillary content), or ``None`` if
+    the session isn't found.
+
+    Example:
+        >>> export = reconstruct_session("abc123", source="phoenix-local-alex")
+        >>> Path("session.md").write_text(export.main_content)
+    """
+    from dev_agent_lens.analysis.chains import get_chain_for_session
+    from dev_agent_lens.export.markdown_litellm import export_chain_to_unified_markdown
+
+    sessions = _query(session_id=session_id, source=source)
+    if not sessions:
+        log.warning(
+            "[fabric] reconstruct_session: session %s not found (source=%s)", session_id, source
+        )
+        return None
+
+    chain = get_chain_for_session(session_id, sessions)
+    if chain is None:
+        # get_chain_for_session drops sessions with no Claude-UUID *and* no temporal
+        # neighbors (a chain-centric assumption from `chain-export`). reconstruct is
+        # session-centric — the caller handed us an id — so synthesize a single-session
+        # chain from the queried spans rather than render nothing.
+        from dev_agent_lens.analysis.chains import ConversationChain, get_session_time_range
+
+        spans = sessions[0].get("spans", [])
+        start, end = get_session_time_range(spans)
+        chain = ConversationChain(
+            chain_id=session_id,
+            session_ids=[session_id],
+            claude_session_id=session_id,
+            total_spans=len(spans),
+            start_time=start,
+            end_time=end,
+        )
+
+    return export_chain_to_unified_markdown(chain, sessions)
+
+
+# ── bulk export ──────────────────────────────────────────────────────────────────
+def _safe_name(session_id: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", session_id)[:120] or "session"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content to path atomically: temp file in the same dir, then ``os.replace``.
+
+    A crash mid-write leaves the temp file (cleaned up), never a truncated ``path`` —
+    so a downstream miner never reads a half-written session (AC: atomic export).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".dal-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)  # atomic on POSIX
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def export_conversations(
+    source: str | None = None,
+    filter: str | None = None,  # noqa: A002 — mirrors the CLI --filter flag
+    pattern: str | None = None,
+    tools: list[str] | None = None,
+    since: str | None = None,
+    limit: int | None = None,
+    output_dir: str | Path = ".",
+    min_spans: int = 0,
+) -> list[Path]:
+    """Bulk-export matching sessions to one markdown file per session, atomically.
+
+    ``filter`` is an alias for ``pattern`` (the CLI exposes ``--filter``). Each file is
+    written temp-then-rename, so a crash never leaves a partial session on disk.
+
+    Returns the list of written paths.
+
+    Example:
+        >>> export_conversations(source="phoenix-lambda2-dal", pattern="transcript",
+        ...                      limit=20, output_dir="./batch/")
+        [PosixPath('batch/abc123.md'), ...]
+    """
+    sessions = list_sessions(
+        source=source,
+        pattern=pattern or filter,
+        tools=tools,
+        since=since,
+        min_spans=min_spans,
+    )
+    if limit is not None:
+        sessions = sessions[:limit]
+
+    out = Path(output_dir)
+    written: list[Path] = []
+    for s in sessions:
+        sid = s.get("session_id")
+        if not sid:
+            continue
+        export = reconstruct_session(sid, source=source)
+        if export is None:
+            log.warning("[fabric] export_conversations: skipped %s (no reconstruction)", sid)
+            continue
+        path = out / f"{_safe_name(sid)}.md"
+        _atomic_write(path, export.main_content)
+        written.append(path)
+
+    log.info(
+        "[fabric] export_conversations: wrote %d/%d session(s) → %s",
+        len(written), len(sessions), out,
+    )
+    return written
+
+
+# ── business-entity lookups (back the meeting/ticket/session-context commands) ────
+def get_meeting_sessions(meeting_id: str) -> list[dict[str, Any]]:
+    """Sessions whose spans reference a meeting id (searched across all sources)."""
+    return _query(search=meeting_id)
+
+
+def get_ticket_sessions(ticket_id: str) -> list[dict[str, Any]]:
+    """Sessions whose spans reference a Linear ticket id, e.g. ENG2-123 (all sources)."""
+    return _query(search=ticket_id)
+
+
+@dataclass
+class SessionContext:
+    """Business context extracted from a session's spans (meetings, tickets, cost)."""
+
+    session_id: str
+    spans: list[dict[str, Any]]
+    token_count: int = 0
+    duration_minutes: float = 0.0
+    meeting_ids: list[str] = field(default_factory=list)
+    ticket_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "span_count": len(self.spans),
+            "token_count": self.token_count,
+            "duration_minutes": round(self.duration_minutes, 2),
+            "meeting_ids": self.meeting_ids,
+            "ticket_ids": self.ticket_ids,
+        }
+
+
+def get_session_context(session_id: str) -> SessionContext:
+    """Meetings, tickets, token cost, and duration referenced by a session.
+
+    Entity ids are extracted from conversation content (best-effort); token/duration
+    come from :func:`analysis.sessions.session_metrics`.
+    """
+    from dev_agent_lens.analysis.sessions import session_metrics
+
+    sessions = _query(session_id=session_id)
+    if not sessions:
+        return SessionContext(session_id=session_id, spans=[])
+
+    spans = sessions[0].get("spans", [])
+    content = _content_text(spans)
+    metrics = session_metrics(spans, session_id=session_id)
+    return SessionContext(
+        session_id=session_id,
+        spans=spans,
+        token_count=metrics.token_count_total,
+        duration_minutes=metrics.duration_minutes,
+        meeting_ids=sorted(set(_UUID_RE.findall(content))),
+        ticket_ids=sorted(set(_TICKET_RE.findall(content))),
+    )

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -171,3 +171,75 @@ Storage is also ~97% smaller (52 GB JSONL → 1.8 GB Parquet with ZSTD).
 | `export_json()` | Export results to JSON |
 | `export_csv()` | Export results to CSV |
 | `export_markdown()` | Export results to Markdown table |
+
+## Conversation reconstruction & mining (fabric)
+
+The `fabric` layer turns raw spans into readable, per-session conversations — one command
+to "give me the conversations matching this signal," so eval mining (IR, M12, …) stops
+re-hand-rolling DuckDB + per-session stitching. It wraps the query → chain → markdown
+pipeline (`dev_agent_lens.fabric`).
+
+### CLI
+
+```bash
+# Reconstruct one session's conversation to markdown (start_time order)
+dal reconstruct-session <session_id> --source phoenix-local-alex -o session.md
+dal reconstruct-session <session_id>                 # print to stdout
+
+# List sessions by content pattern, tool usage, date, and size (newest first)
+dal list-sessions --source phoenix-local-alex \
+  --pattern transcript \
+  --tools 'mcp__claude_ai_Linear,mcp__claude_ai_Notion' \
+  --min-spans 50 --since 2026-05-01 \
+  --output json
+
+# Bulk-export N matching sessions to one .md per session (written atomically)
+dal export-conversations --source phoenix-lambda2-dal \
+  --filter transcript --limit 20 -o ./mining-batch/
+```
+
+Omit `--source` to fan out across every source under `~/.dal/data`.
+
+### Python API
+
+```python
+from dev_agent_lens.fabric import (
+    list_sessions,         # filters → session dicts (newest first)
+    reconstruct_session,   # session_id → markdown export, in time order
+    export_conversations,  # bulk write one .md per session, atomically
+)
+
+# Fan out a batch of gold examples for a miner
+for path in export_conversations(source="phoenix-local-alex",
+                                 pattern="transcript", limit=20,
+                                 output_dir="./batch/"):
+    print(path)
+
+# Or one at a time
+export = reconstruct_session("abc123", source="phoenix-local-alex")
+Path("session.md").write_text(export.main_content)
+```
+
+`export_conversations` writes each file temp-then-rename, so a crash never leaves a
+partial session on disk — safe to point a miner at the output dir while it runs.
+
+### Business-entity lookups
+
+`dal meeting-sessions <id>`, `dal ticket-sessions ENG2-123`, and
+`dal session-context <session_id>` surface which sessions reference a meeting / ticket,
+and what entities (meetings, tickets), tokens, and duration a session touched.
+
+### Notes
+
+- **Reconstruction** links a session's spans into a `ConversationChain` (grouping by
+  Claude session-UUID, or temporal proximity). A session with no recognizable UUID and no
+  neighbours is rendered as a standalone single-session chain rather than dropped.
+- **Filtering**: `--pattern`/`--filter` and `--since`/`--until` push down into the parquet
+  query; `--tools` and `--min-spans` are applied on top.
+
+| Function | Description |
+|----------|-------------|
+| `list_sessions()` | Sessions matching pattern/tool/date/size filters, newest first |
+| `reconstruct_session()` | One session → markdown export in start_time order |
+| `export_conversations()` | Bulk per-session `.md` export, written atomically |
+| `get_session_context()` | Meetings/tickets/tokens/duration referenced by a session |

--- a/tests/test_fabric_queries.py
+++ b/tests/test_fabric_queries.py
@@ -1,0 +1,98 @@
+"""Unit tests for the fabric convenience layer (ENG2-1313).
+
+The heavy downstream (parquet query, chain building, markdown rendering) is smoke-
+verified against real data separately; here we mock it so the WRAPPER logic —
+source fan-out, filters, the list→reconstruct→export pipeline, and atomic writes —
+is exercised deterministically without a parquet corpus.
+"""
+
+from unittest.mock import patch
+
+from dev_agent_lens.fabric import queries
+
+# A single known session shaped like query_sessions() output.
+_SESSION = {
+    "session_id": "test-sess-1",
+    "spans": [
+        {
+            "input_value": "look at meeting 11111111-1111-1111-1111-111111111111 for ENG2-999",
+            "output_value": "on it",
+            "name": "llm",
+        }
+    ],
+    "span_count": 1,
+    "start_time": "2026-06-01T10:00:00",
+    "end_time": "2026-06-01T10:05:00",
+}
+
+
+class _FakeExport:
+    main_content = "# Session: test-sess-1\n\nlook at meeting …\n"
+    subagent_files: dict = {}
+    tool_result_files: dict = {}
+
+
+def test_list_reconstruct_export_pipeline(tmp_path):
+    """The headline pipeline: list a session, reconstruct it, bulk-export it atomically."""
+    with (
+        patch.object(queries, "_query", return_value=[dict(_SESSION)]),
+        patch(
+            "dev_agent_lens.export.markdown_litellm.export_chain_to_unified_markdown",
+            return_value=_FakeExport(),
+        ),
+        patch("dev_agent_lens.analysis.chains.get_chain_for_session", return_value=object()),
+    ):
+        # 1. list
+        sessions = queries.list_sessions(source="x")
+        assert len(sessions) == 1
+        assert sessions[0]["session_id"] == "test-sess-1"
+
+        # 2. reconstruct
+        export = queries.reconstruct_session("test-sess-1", source="x")
+        assert export is not None
+        assert export.main_content.startswith("# Session: test-sess-1")
+
+        # 3. export (bulk, atomic)
+        written = queries.export_conversations(source="x", output_dir=tmp_path)
+        assert len(written) == 1
+        out = written[0]
+        assert out.exists()
+        assert out.read_text(encoding="utf-8") == _FakeExport.main_content
+        # atomic writer leaves no partial temp file behind
+        assert not list(tmp_path.glob(".dal-*.tmp"))
+
+
+def test_list_sessions_min_spans_filter():
+    """min_spans drops sessions below the threshold."""
+    with patch.object(queries, "_query", return_value=[dict(_SESSION)]):
+        assert len(queries.list_sessions(min_spans=1)) == 1
+        assert queries.list_sessions(min_spans=2) == []
+
+
+def test_list_sessions_tools_filter():
+    """tools keeps only sessions whose spans reference ALL named tools."""
+    s = dict(_SESSION)
+    s["spans"] = [{"input_value": "used mcp__claude_ai_Linear here", "output_value": ""}]
+    with patch.object(queries, "_query", return_value=[s]):
+        assert len(queries.list_sessions(tools=["mcp__claude_ai_Linear"])) == 1
+        assert queries.list_sessions(tools=["mcp__claude_ai_Notion"]) == []
+
+
+def test_reconstruct_missing_session_returns_none():
+    with patch.object(queries, "_query", return_value=[]):
+        assert queries.reconstruct_session("nope") is None
+
+
+def test_get_session_context_extracts_entities():
+    """session-context pulls meeting UUIDs + ticket ids from conversation content."""
+    metrics = type("M", (), {"token_count_total": 42, "duration_minutes": 5.0})()
+    with (
+        patch.object(queries, "_query", return_value=[dict(_SESSION)]),
+        patch("dev_agent_lens.analysis.sessions.session_metrics", return_value=metrics),
+    ):
+        ctx = queries.get_session_context("test-sess-1")
+        assert ctx.token_count == 42
+        assert ctx.duration_minutes == 5.0
+        assert "ENG2-999" in ctx.ticket_ids
+        assert "11111111-1111-1111-1111-111111111111" in ctx.meeting_ids
+        assert ctx.to_dict()["session_id"] == "test-sess-1"


### PR DESCRIPTION
## Summary

DAL convenience tooling — a `dev_agent_lens/fabric/` layer so eval mining (IR, M12, …) stops hand-rolling DuckDB + per-session stitching. Thin wrappers over the existing query → chain → markdown pipeline.

- **`reconstruct_session(id)`** → markdown conversation in start_time order
- **`list_sessions(pattern/tools/since/min_spans)`** → session dicts, fanned across all sources
- **`export_conversations(...)`** → bulk per-session `.md`, written **atomically** (temp + `os.replace` — no partial files on crash, safe to point a miner at while it runs)
- **Fixes 3 broken CLI stubs** — `dal meeting-sessions` / `ticket-sessions` / `session-context` imported a non-existent `fabric.queries`; now wired (`get_meeting_sessions` / `get_ticket_sessions` / `get_session_context`)

**CLI:** `dal reconstruct-session` / `list-sessions` / `export-conversations`.

## Test Plan
- [x] **Smoke-verified against real parquet data** (`my-phoenix`): list (3) → reconstruct (15.9K chars md) → export (atomic) → context (extracted meetings + tickets)
- [x] **5 unit tests** — pipeline, tool + min-spans filters, atomic write (no temp leftover), entity extraction: `5 passed`
- [x] ruff-clean (new code); CLI verbs verified
- [x] Documented in `docs/querying.md`

Fixes ENG2-1313.

## Notes
- `reconstruct` falls back to a synthesized single-session chain for sessions the chain-builder drops (no Claude-UUID + no temporal neighbours) — so session-centric reconstruct never renders nothing.
- `dal cost` imports a *separate* `fabric.analysis` module (cost analysis) — still a broken stub, but out of this ticket's scope.

Generated with Claude Code