### PR TITLE
docs: fix cookbook recipe 3 — rows.tail collides with DataFrame.tail()

### DIFF
--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -94,7 +94,7 @@ rows = con.execute("""
 """).df()
 
 import re
-candidates = [m.group(1) for t in rows.tail.dropna()
+candidates = [m.group(1) for t in rows["tail"].dropna()
               if (m := re.search(r"'text': '([^']{5,400})", t))]
 for turn in extract_human_turns(candidates):
     print("•", turn)


### PR DESCRIPTION
One-line fix: the recipe's `tail` column is shadowed by pandas' `DataFrame.tail()` method under attribute access, so recipe 3 as written throws `AttributeError`. `rows["tail"]` accesses the column.

Found by a `dal-workload` acceptance rollout (ENG2-1418, AIT PR #140) running the recipe verbatim against the synthetic Phoenix fixture — the DAL-as-workload pattern surfacing a real defect in the tooling under analysis, first week out.

Generated with Claude Code

https://claude.ai/code/session_01NvLHxnTX86Afii9jz8ZGQQ