### PR TITLE
fix: reconstruct-live counts compactions when marker is haiku-only (ENG2-1441)

### DIFF
--- a/dev_agent_lens/analysis/live_reconstruct.py
+++ b/dev_agent_lens/analysis/live_reconstruct.py
@@ -83,11 +83,25 @@ def _stringify_tool_result(content: Any) -> str:
 
 
 def _extract_compaction_summary(text: str) -> str:
-    """Pull the summary body out of a post-compaction continuation message."""
-    marker = COMPACTION_SUMMARY_MARKER
-    idx = text.find(marker)
-    if idx != -1:
-        return text[idx:]
+    """Pull the summary body out of a post-compaction continuation message.
+
+    The continuation message's ``content`` is a stringified block list, and the
+    summary lives in the single text block carrying the continuation marker.
+    Return just that block, so the rendered marker is the summary itself rather
+    than the entire cumulative history the block list also carries (which on
+    real spans is tens of KB — see ENG2-1441).
+    """
+    for block in _parse_message_content(text):
+        if block.get("type") == "text":
+            btext = block.get("text", "")
+            if COMPACTION_CONTINUATION_MARKER in btext:
+                return btext
+    # Fallbacks for shapes the block parser can't split: slice from whichever
+    # marker is present so we never dump the whole history verbatim.
+    for marker in (COMPACTION_SUMMARY_MARKER, COMPACTION_CONTINUATION_MARKER):
+        idx = text.find(marker)
+        if idx != -1:
+            return text[idx:]
     return text
 
 
@@ -120,6 +134,10 @@ def build_session_records(
     total_tokens = 0
     models_used: dict[str, int] = {}
     compaction_count = 0
+    # Dedup compactions by summary: the same continuation persists in the
+    # cumulative history of every later span on prod, so a raw per-span count
+    # would multiply one compaction into dozens.
+    seen_compaction_keys: set[int] = set()
 
     timestamps: list[Any] = []
     for span in ordered:
@@ -130,10 +148,41 @@ def build_session_records(
         if ts_end:
             timestamps.append(ts_end)
 
+        input_messages = _extract_input_messages_array(span)
+
+        # ---- Compaction detection (runs for EVERY span, incl. haiku) ---------
+        # On real data the post-compaction continuation marker can land only on
+        # a background *haiku* span (e.g. a title/topic call that carries the
+        # resumed context) — no main-model span in the window carries it. The
+        # haiku skip below drops such spans from the conversation body, so
+        # detection MUST run first or the compaction is missed entirely, which
+        # is exactly the ENG2-1441 bug (0 compactions on a compacted session).
+        for msg in input_messages:
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content", "")
+            content_str = content if isinstance(content, str) else str(content)
+            if COMPACTION_CONTINUATION_MARKER not in content_str:
+                continue
+            summary = _extract_compaction_summary(content_str)
+            key = hash(summary[:500])
+            if key in seen_compaction_keys:
+                break  # same compaction, already counted on an earlier span
+            seen_compaction_keys.add(key)
+            compaction_count += 1
+            events.append({
+                "record_type": "event",
+                "event_type": "compaction",
+                "number": compaction_count,
+                "summary": summary,
+            })
+            break  # one continuation marker per span
+
         # Claude Code routes ancillary background work (quota checks, topic
         # detection, conversation-title generation, bash-safety checks) to
         # Haiku. Those are not part of the main conversation, so skip them for
-        # parity with `dal reconstruct`'s main-thread-only default.
+        # parity with `dal reconstruct`'s main-thread-only default. (Compaction
+        # was already detected above, so a haiku-only marker isn't lost.)
         model = _extract_model(span)
         if "haiku" in model.lower():
             continue
@@ -145,21 +194,15 @@ def build_session_records(
         total_tokens += int(span.get("llm_token_count_completion") or 0)
 
         # ---- User side: input_messages (one user message per exchange) --------
-        for msg in _extract_input_messages_array(span):
+        for msg in input_messages:
             if msg.get("role") != "user":
                 continue
             content = msg.get("content", "")
             content_str = content if isinstance(content, str) else str(content)
 
-            # Compaction: the post-compaction continuation carries the summary
+            # Compaction continuation already counted above; don't re-emit it as
+            # a user turn.
             if COMPACTION_CONTINUATION_MARKER in content_str:
-                compaction_count += 1
-                events.append({
-                    "record_type": "event",
-                    "event_type": "compaction",
-                    "number": compaction_count,
-                    "summary": _extract_compaction_summary(content_str),
-                })
                 continue
             # The summarization request itself is not a human turn — skip its
             # (huge) prompt rather than dumping it as user text.

--- a/dev_agent_lens/analysis/live_reconstruct.py
+++ b/dev_agent_lens/analysis/live_reconstruct.py
@@ -165,7 +165,11 @@ def build_session_records(
             if COMPACTION_CONTINUATION_MARKER not in content_str:
                 continue
             summary = _extract_compaction_summary(content_str)
-            key = hash(summary[:500])
+            # Key on the full summary (already bounded to the continuation block,
+            # not the whole history): two real compactions share a ~160-char
+            # boilerplate preamble, so a truncated key could collapse distinct
+            # summaries into one.
+            key = hash(summary)
             if key in seen_compaction_keys:
                 break  # same compaction, already counted on an earlier span
             seen_compaction_keys.add(key)

--- a/tests/analysis/test_live_reconstruct.py
+++ b/tests/analysis/test_live_reconstruct.py
@@ -177,6 +177,74 @@ def test_compaction_summary_becomes_event():
     assert header["compaction_count"] == 1
 
 
+def test_compaction_marker_on_haiku_span_is_detected():
+    """Regression for ENG2-1441 — the shape a synthetic clean test can't catch.
+
+    On real prod/seed data the ONLY span carrying the post-compaction
+    continuation marker is a *haiku* background call (a title/topic call that
+    carries the resumed context); no main-model span in the window carries it.
+    The marker also sits several blocks deep in a python-repr content string and
+    uses the "The summary below covers..." phrasing (no `SUMMARY_MARKER`). The
+    original code skipped all haiku spans BEFORE detection, so it reported 0
+    compactions on a genuinely compacted session. Detection must fire anyway.
+    """
+    continuation = (
+        "This session is being continued from a previous conversation that ran "
+        "out of context. The summary below covers the earlier portion of the "
+        "conversation.\\n\\nSummary:\\n## 1. Primary Request and Intent\\n\\n"
+        "The user asked to implement ticket ENG2-1431."
+    )
+    haiku_span = _span(
+        "2026-07-23T12:00:05",
+        "claude-haiku-4-5-20251001",
+        # Multiple blocks, marker is NOT first — mirrors the real cumulative
+        # history the haiku call receives as context.
+        "[{'type': 'text', 'text': '<system-reminder>\\nnoise\\n</system-reminder>'}, "
+        f'{{\'type\': \'text\', \'text\': "{continuation}"}}]',
+        "[{'type': 'text', 'text': 'ancillary haiku output'}]",
+    )
+    opus_span = _span(
+        "2026-07-23T12:00:06",
+        "claude-opus-4-8",
+        "[{'type': 'text', 'text': 'a real human turn after the compaction here'}]",
+        "[{'type': 'text', 'text': 'picking up where we left off'}]",
+    )
+    records = build_session_records("s", [haiku_span, opus_span])
+    header = records[0]
+    evts = _events(records)
+
+    compactions = [e for e in evts if e["event_type"] == "compaction"]
+    assert len(compactions) == 1, "haiku-only continuation marker must be counted"
+    assert header["compaction_count"] == 1
+    # Summary is bounded to the continuation block, not the whole history.
+    assert compactions[0]["summary"].startswith("This session is being continued")
+    assert "ENG2-1431" in compactions[0]["summary"]
+    assert "<system-reminder>" not in compactions[0]["summary"]
+    # The haiku span's ancillary body is still excluded from the conversation.
+    assert all(e.get("text") != "ancillary haiku output" for e in evts)
+    assert header["metrics"]["models_used"] == {"claude-opus-4-8": 1}
+
+
+def test_compaction_deduped_across_cumulative_spans():
+    """The same continuation persists in later spans' cumulative history on prod;
+    it must count as ONE compaction, not one per span carrying it."""
+    continuation = (
+        "This session is being continued from a previous conversation that ran "
+        "out of context.\\n\\nSummary:\\n## 1. Primary Request and Intent"
+    )
+    user_content = f'[{{\'type\': \'text\', \'text\': "{continuation}"}}]'
+    spans = [
+        _span("2026-07-23T12:00:00", "claude-opus-4-8", user_content,
+              "[{'type': 'text', 'text': 'reply one'}]"),
+        _span("2026-07-23T12:00:01", "claude-opus-4-8", user_content,
+              "[{'type': 'text', 'text': 'reply two'}]"),
+    ]
+    records = build_session_records("s", spans)
+    compactions = [e for e in _events(records) if e["event_type"] == "compaction"]
+    assert len(compactions) == 1
+    assert records[0]["compaction_count"] == 1
+
+
 def test_output_at_parity_with_renderer():
     """The records must render cleanly through the shared markdown renderer."""
     spans = [

--- a/tests/analysis/test_live_reconstruct.py
+++ b/tests/analysis/test_live_reconstruct.py
@@ -245,6 +245,34 @@ def test_compaction_deduped_across_cumulative_spans():
     assert records[0]["compaction_count"] == 1
 
 
+def test_two_distinct_compactions_counted_separately():
+    """Dedup must collapse the SAME continuation across cumulative spans, but
+    must NOT collapse two DIFFERENT compactions in one session — even though
+    real summaries share a long boilerplate preamble. Guards the dedup-key
+    window against the ENG2-1441 class of 'clean assumption breaks on real
+    data'."""
+    preamble = (
+        "This session is being continued from a previous conversation that ran "
+        "out of context. The summary below covers the earlier portion of the "
+        "conversation.\\n\\nSummary:\\n## 1. Primary Request and Intent\\n\\n"
+    )
+    first = preamble + "The user asked to implement ticket ENG2-1431."
+    second = preamble + "The user asked to refactor the export pipeline."
+    spans = [
+        _span("2026-07-23T12:00:00", "claude-opus-4-8",
+              f'[{{\'type\': \'text\', \'text\': "{first}"}}]',
+              "[{'type': 'text', 'text': 'reply one'}]"),
+        _span("2026-07-23T13:00:00", "claude-opus-4-8",
+              f'[{{\'type\': \'text\', \'text\': "{second}"}}]',
+              "[{'type': 'text', 'text': 'reply two'}]"),
+    ]
+    records = build_session_records("s", spans)
+    compactions = [e for e in _events(records) if e["event_type"] == "compaction"]
+    assert len(compactions) == 2
+    assert records[0]["compaction_count"] == 2
+    assert compactions[0]["number"] == 1 and compactions[1]["number"] == 2
+
+
 def test_output_at_parity_with_renderer():
     """The records must render cleanly through the shared markdown renderer."""
     spans = [


### PR DESCRIPTION
## Summary

`dal reconstruct-live` reported **0 compactions** on a genuinely compacted session (ENG2-1441), rendering the continuation summary as a normal turn instead of a compaction marker. Fixed by running compaction detection for **every** span, before the haiku skip.

### Root cause (verified against the real seed session `629017da`)

The extractor already unwraps the `{"message": {...}}` shape, so extraction was fine. The actual gate was upstream: on real data the **only** span carrying the continuation marker (`This session is being continued from a previous conversation`) is a background **haiku** span — no main-model (opus) span in the window carries it anywhere. `build_session_records` skipped all haiku spans at the top of the loop *before* the marker check, so the compaction was discarded before it was ever seen.

### Fix

- Run compaction detection for every span, **before** the haiku skip, so a haiku-only marker is still counted. Haiku ancillary body content stays excluded from the conversation.
- Dedup by summary hash — the same continuation persists in later spans' cumulative history on prod and would otherwise multiply one compaction into many.
- Bound `_extract_compaction_summary` to the continuation text block (the seed's block is ~13KB inside a ~60KB history; the old code returned the whole history because this session uses the `Summary:` phrasing, not `SUMMARY_MARKER`).

### Verification (real command against the read-only seed)

```
# compacted 629017da  → 1 compactions (was 0), renders "### Compaction #1"
Wrote 126,955 chars → /tmp/c.md (12 user, 98 assistant, 137 tool results, 1 compactions)
# non-compacted 8cf39ac5 → unchanged, still 0
Wrote 18,019 chars → /tmp/nc.md (4 user, 4 assistant, 34 tool results, 0 compactions)
```

The new regression test uses the **real** haiku-wrapped shape and fails on the pre-fix code (`0 = len([])`); the prior synthetic clean-shape test could not catch this. Full suite: 201 passed.

## Test plan

- [x] `dal reconstruct-live 629017da --days 30` reports compactions > 0 and renders the marker
- [x] non-compacted `8cf39ac5` unchanged (0 compactions, coherent)
- [x] `pytest tests/analysis tests/export` → 201 passed
- [x] new test fails on old code, passes on new

🤖 Generated with [Claude Code](https://claude.com/claude-code)