### PR TITLE
fix: drop dangling compaction sidecar link on live reconstruct paths (ENG2-1446)

### DIFF
--- a/dev_agent_lens/export/markdown_renderer.py
+++ b/dev_agent_lens/export/markdown_renderer.py
@@ -605,14 +605,30 @@ def _render_compaction_section(
     lines.append("<!-- END PIPELINE_SPECIFIC -->")
     lines.append("")
 
-    # Context summary (outside PIPELINE_SPECIFIC per spec)
-    # Truncate long summaries and create external file
-    if len(summary) > COMPACTION_SUMMARY_INLINE_LIMIT and tool_result_files is not None:
-        # Store full summary in external file
+    # Context summary (outside PIPELINE_SPECIFIC per spec).
+    #
+    # Only the Claude-JSONL path (`dal reconstruct`, pipeline="claude") persists
+    # `tool_result_files` to disk (via `export_to_files`), so only there can a
+    # `→ Full summary: [compaction_N_summary.txt]` link actually resolve. There
+    # the summary is the *full* post-compaction continuation message and can be
+    # large, so we keep the truncate-inline + sidecar-file behavior.
+    #
+    # The live path (`dal reconstruct-live`, pipeline="litellm") renders only
+    # `main_content` and discards `tool_result_files` — so emitting that link
+    # would dangle (ENG2-1446). Its summary is already bounded to the
+    # continuation block by ENG2-1441, so render it inline with no pointer,
+    # matching the LiteLLM renderer used by `dal reconstruct-session`.
+    write_sidecar = (
+        pipeline == "claude"
+        and len(summary) > COMPACTION_SUMMARY_INLINE_LIMIT
+        and tool_result_files is not None
+    )
+    if write_sidecar:
+        # Store full summary in an external file the caller will write to disk.
         filename = f"compaction_{number}_summary"
         tool_result_files[filename] = summary
 
-        # Show truncated inline with link
+        # Show truncated inline with a link to the sidecar.
         truncated = truncate(summary, COMPACTION_SUMMARY_INLINE_LIMIT)
         lines.append("> **Context Summary**:")
         for line in truncated.split("\n"):

--- a/tests/analysis/test_live_reconstruct.py
+++ b/tests/analysis/test_live_reconstruct.py
@@ -13,10 +13,15 @@ right conversation events:
 
 from __future__ import annotations
 
+import inspect
 import json
 
 from dev_agent_lens.analysis.live_reconstruct import build_session_records
-from dev_agent_lens.export.markdown_renderer import render_jsonl_to_markdown
+from dev_agent_lens.export.markdown_renderer import (
+    COMPACTION_SUMMARY_INLINE_LIMIT,
+    _render_compaction_section,
+    render_jsonl_to_markdown,
+)
 
 
 def _span(start, model, user_content, assistant_content, tokens=(10, 5)):
@@ -291,3 +296,91 @@ def test_output_at_parity_with_renderer():
     assert "### Assistant" in export.main_content
     assert export.stats["user_turns"] == 1
     assert export.stats["assistant_turns"] == 1
+
+
+# ── ENG2-1446: no dangling `→ Full summary` sidecar link ──────────────────────
+
+def test_long_compaction_summary_renders_inline_with_no_sidecar_link():
+    """A compaction summary longer than the old inline limit must render fully
+    inline — NO `→ Full summary` link and NO `compaction_N_summary` sidecar.
+
+    The reconstruct-live/reconstruct-session CLIs write only `main_content` and
+    discard `tool_result_files`, so any such link would dangle (ENG2-1446).
+    """
+    long_summary = "SUMMARY_SENTINEL " + ("blah " * COMPACTION_SUMMARY_INLINE_LIMIT)
+    assert len(long_summary) > COMPACTION_SUMMARY_INLINE_LIMIT  # guard the premise
+
+    tool_result_files: dict[str, str] = {}
+    lines = _render_compaction_section(
+        1,
+        long_summary,
+        pipeline="litellm",
+        tool_result_files=tool_result_files,
+    )
+    out = "\n".join(lines)
+
+    # No dangling pointer of any form.
+    assert "Full summary" not in out
+    assert "compaction_" not in out
+    assert ".txt" not in out
+    # And nothing was stashed for a sidecar the CLI would never write.
+    assert tool_result_files == {}
+    # The summary itself is present inline (bounded, but not linked away).
+    assert "SUMMARY_SENTINEL" in out
+    assert "> **Context Summary**:" in out
+
+
+def test_reconstruct_live_export_has_no_compaction_sidecar_file():
+    """End-to-end through the shared renderer: a long compaction summary leaves
+    no `compaction_*` entry in `export.tool_result_files` and no dangling link
+    in `main_content`."""
+    long_summary = "END_TO_END_SENTINEL " + ("x " * COMPACTION_SUMMARY_INLINE_LIMIT)
+    records = [
+        {"record_type": "header", "session_id": "sess-1446", "compaction_count": 1},
+        {
+            "record_type": "event",
+            "event_type": "compaction",
+            "number": 1,
+            "summary": long_summary,
+        },
+    ]
+    export = render_jsonl_to_markdown(records)
+
+    assert "Full summary" not in export.main_content
+    assert "END_TO_END_SENTINEL" in export.main_content
+    assert not any(k.startswith("compaction_") for k in export.tool_result_files)
+
+
+def test_claude_pipeline_still_writes_sidecar_and_link():
+    """Gate boundary: the `dal reconstruct` (pipeline="claude") path DOES persist
+    `tool_result_files` to disk (via `export_to_files`), so it keeps the
+    truncate-inline + `→ Full summary` sidecar link for long summaries. ENG2-1446
+    only drops the link on the live path that discards those files — don't let a
+    future refactor silently strip the sidecar the Claude path actually writes."""
+    long_summary = "CLAUDE_SENTINEL " + ("blah " * COMPACTION_SUMMARY_INLINE_LIMIT)
+
+    tool_result_files: dict[str, str] = {}
+    lines = _render_compaction_section(
+        1,
+        long_summary,
+        pipeline="claude",
+        tool_result_files=tool_result_files,
+    )
+    out = "\n".join(lines)
+
+    assert "→ Full summary: [compaction_1_summary.txt](./compaction_1_summary.txt)" in out
+    assert tool_result_files["compaction_1_summary"] == long_summary
+
+
+def test_reconstruct_session_litellm_path_has_no_dangling_link():
+    """Criterion 2: the reconstruct-session renderer (markdown_litellm) already
+    renders the compaction summary inline with no `→ Full summary` pointer, so it
+    never emitted the dangling link. Pin that so it can't regress into one."""
+    from dev_agent_lens.export import markdown_litellm
+
+    src = inspect.getsource(markdown_litellm)
+    # The litellm renderer must not introduce a compaction sidecar pointer.
+    assert "Full summary" not in src
+    assert "compaction_{" not in src  # no f-string sidecar filename
+    # It does render the summary inline under a Context Summary blockquote.
+    assert "Previous Context Summary" in src


### PR DESCRIPTION
## Problem

`dal reconstruct-live` rendered a dangling link for long compaction summaries:

```
→ Full summary: [compaction_1_summary.txt](./compaction_1_summary.txt)
```

…but the CLI writes only `export.main_content` and discards `export.tool_result_files`, so the referenced file was never written. Pre-existing / low severity; surfaced by the adversarial review during the ENG2-1441 rollout (#47), which bounded the summary but didn't remove the link.

## Fix

Gate the sidecar-file write + `→ Full summary` link on `pipeline == "claude"` in `_render_compaction_section`:

- **`pipeline == "claude"`** (`dal reconstruct`): unchanged — it persists `tool_result_files` to disk via `export_to_files`, so the link resolves. Keeps truncate-inline + sidecar for large (unbounded) Claude-JSONL summaries.
- **`pipeline == "litellm"`** (`dal reconstruct-live`, which discards `tool_result_files`): render the ENG2-1441-bounded summary **inline, no sidecar, no link**.

### Scope note
- `reconstruct-session` never emitted this link — it uses a *different* renderer (`markdown_litellm`) that already renders the summary inline with no pointer. Criterion 2 is satisfied by existing behavior; pinned with a test.
- Deliberately **not** unifying all renderers — the `claude`/`export_to_files` path legitimately writes the sidecar, so its link is not dangling.

## Acceptance
- [x] Live reconstruction with a long compaction summary emits no dangling link.
- [x] Same for `reconstruct-session` (already inline, no pointer — pinned).
- [ ] Verify against real compacted session `629017da-644d-4dd9-b82a-c6182f007d2b` (needs `PHOENIX_SQL_DATABASE_URL`; to be run host-side).

## Tests
Added 4 tests to `tests/analysis/test_live_reconstruct.py`; 14 compaction tests pass (4 new + 10 existing, incl. the `claude`-path sidecar tests).

```
14 passed, 71 deselected in 0.25s
```

## Related
- ENG2-1441 (#47) — compaction-aware rendering fix, where this was found
- ENG2-1435 (#46) — parent, reconstruct-live

🤖 Generated with [Claude Code](https://claude.com/claude-code)