### PR TITLE
fix(archive_spans): pin both engines to UTC for bucket verification

### DIFF
--- a/scripts/archive_spans.py
+++ b/scripts/archive_spans.py
@@ -76,6 +76,10 @@ def connect(dsn: str, timeout_s: int) -> psycopg.Connection:
     conn = psycopg.connect(dsn, connect_timeout=15)
     conn.execute(f"SET statement_timeout = '{timeout_s}s'")
     conn.execute("SET default_transaction_read_only = on")
+    # Bucket comparisons (date_trunc) must agree with DuckDB, which truncates
+    # parquet timestamps in UTC — a non-UTC session TZ shuffles boundary rows
+    # between week buckets and fails verify with zero actual drift.
+    conn.execute("SET TIME ZONE 'UTC'")
     return conn
 
 
@@ -189,6 +193,10 @@ def verify(conn: psycopg.Connection, out_dir: Path, sample_n: int) -> dict:
     import duckdb
 
     duck = duckdb.connect()
+    # Same UTC pinning as the PG session (see connect()): DuckDB's date_trunc
+    # on timestamptz uses its TimeZone setting, which defaults to the SYSTEM
+    # timezone — bucket comparisons need both engines truncating in UTC.
+    duck.execute("SET TimeZone='UTC'")
     glob = str(out_dir / "spans_*.parquet")
     report: dict = {"ok": True, "checks": []}
 


### PR DESCRIPTION
Follow-up to #50: week-bucket verification compared PG date_trunc (session TZ) against DuckDB date_trunc (system TZ). On a non-UTC host that shuffles boundary rows between week buckets and fails verify with zero actual drift — confirmed by exact id-set diff in both directions (0 missing, 0 extra). With both engines pinned to UTC, the full 1.31M-span archive verifies **9/9 PASS** including exact-content sampling.

Linear: ENG2-1461

https://claude.ai/code/session_01576WYt25ghMCanhe8wYCCf