### PR TITLE
Session-usage catalog pipeline: dal_catalog.sessions (ENG2-1470)

### DIFF
--- a/scripts/dal_catalog/README.md
+++ b/scripts/dal_catalog/README.md
@@ -1,0 +1,43 @@
+# DAL session-usage catalog (ENG2-1470)
+
+One-shot (re-runnable) pipeline that catalogs every historical Dev Agent Lens /
+Claude session into `dal_catalog.sessions` in the shared Supabase — the ground
+truth for "how is DAL actually used" ahead of the DAL 2.0 architecture decision
+(ENG2-1471 Notion doc, OLTP vs OLAP).
+
+## Tables
+
+- `dal_catalog.sessions` — one row per session_id: sources, person, project,
+  time range, call/turn/tool counts, first prompt, LLM-assigned `category` +
+  `summary`, ticket mentions, rollout metadata. Droppable if it doesn't earn
+  its keep.
+- `dal_catalog.accounts` — account_uuid → email/name (Adam, Alex, Will, Yashwanth).
+
+## Sources (merged by session_id)
+
+1. **phoenix_archive** — `litellm_request` spans in the 2026-08-03 parquet
+   archive (`~/dal-archive/phoenix-2026-08-03`), grouped by the
+   `user_api_key_end_user_id.session_id` tag. Cross-machine, 2026-05-06 → 08-03.
+   ~14.5k early calls have no session tag and are deliberately excluded.
+2. **sandbox_rollout** — `sandbox_agent_sessions` across all `workspace_*` schemas.
+3. **local_jsonl** — `~/.claude/projects/-Users-vanities-git-work-teraflop*/` on
+   Adam's machine (teraflop paths only; personal projects deliberately excluded).
+   Note: Claude Code prunes local JSONLs (~30 days), hence the archive source.
+
+## Run order
+
+```bash
+DSN=$PHOENIX_SQL_DATABASE_URL   # dev-agent-lens/.env
+uv run --with 'psycopg[binary]' --with duckdb --with pytz python catalog_ingest.py "$DSN" all
+uv run --with 'psycopg[binary]' --with duckdb --with pytz python extract_content.py "$DSN"
+# categorize: 14 parallel Claude subagents over session_samples/ (see ENG2-1470
+# session 2026-08-04) writing categorized/batch_*.jsonl, then:
+uv run --with 'psycopg[binary]' python apply_categories.py "$DSN"
+```
+
+Categories are a seeded taxonomy (ir-eval, ticket-implementation, meeting-qa,
+customer-work, workspace-rollout-infra, infra-ops, …) plus emergent labels
+normalized after the fact (hivemind, planning-triage, business-ops, …).
+
+First full run (2026-08-04): 1,333 sessions, 0 uncategorized. Distribution and
+findings: see ENG2-1470.

--- a/scripts/dal_catalog/apply_categories.py
+++ b/scripts/dal_catalog/apply_categories.py
@@ -1,0 +1,60 @@
+"""ENG2-1470 phase 2b: apply subagent categorization results to dal_catalog.sessions.
+
+Reads categorized/batch_*.jsonl, validates, updates category/summary (+confidence
+in meta). Reports coverage and category distribution.
+"""
+
+import glob
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(message)s",
+                    datefmt="%H:%M:%S", stream=sys.stderr)
+log = logging.getLogger("apply")
+
+DSN = sys.argv[1]
+HERE = Path(__file__).parent
+
+t0 = time.perf_counter()
+rows, bad = {}, 0
+files = sorted(glob.glob(str(HERE / "categorized" / "batch_*.jsonl")))
+for f in files:
+    for line in open(f):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+            assert r["session_id"] and r["category"]
+            rows[r["session_id"]] = r  # last write wins on dupes
+        except Exception:
+            bad += 1
+log.info("loaded %d results from %d files (%d bad lines)", len(rows), len(files), bad)
+
+with psycopg.connect(DSN, connect_timeout=15) as conn, conn.cursor() as cur:
+    n = 0
+    for sid, r in rows.items():
+        cur.execute(
+            """UPDATE dal_catalog.sessions
+               SET category = %s, summary = %s,
+                   meta = coalesce(meta, '{}'::jsonb) || %s
+               WHERE session_id = %s""",
+            (r["category"][:80], (r.get("summary") or "")[:300],
+             Jsonb({"category_confidence": r.get("confidence")}), sid))
+        n += cur.rowcount
+    conn.commit()
+    log.info("updated %d rows in %.1fs", n, time.perf_counter() - t0)
+
+    cur.execute("""SELECT coalesce(category,'(uncategorized)'), count(*)
+                   FROM dal_catalog.sessions GROUP BY 1 ORDER BY 2 DESC""")
+    print("\n=== category distribution ===")
+    for cat, cnt in cur.fetchall():
+        print(f"  {cnt:5d}  {cat}")
+    cur.execute("SELECT count(*) FROM dal_catalog.sessions WHERE category IS NULL")
+    print("uncategorized:", cur.fetchone()[0])

--- a/scripts/dal_catalog/catalog_ingest.py
+++ b/scripts/dal_catalog/catalog_ingest.py
@@ -1,0 +1,259 @@
+"""ENG2-1470: catalog all historical DAL / Claude session usage into Postgres.
+
+Creates dal_catalog.sessions (droppable) and ingests three sources, merged
+by session_id:
+  A. phoenix_archive  — litellm_request spans in the 2026-08-03 parquet archive,
+                        grouped by the session_id tag (cross-machine, May-Aug)
+  B. sandbox_rollout  — sandbox_agent_sessions across all workspace_* schemas
+  C. local_jsonl      — ~/.claude/projects/*/<uuid>.jsonl on this machine
+
+Usage: python catalog_ingest.py <DSN> [archive|rollouts|local|all]
+"""
+
+import glob
+import json
+import logging
+import os
+import re
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+import duckdb
+import psycopg
+from psycopg.types.json import Jsonb
+
+logging.basicConfig(level=logging.INFO, format="[%(asctime)s] [%(name)s] %(message)s",
+                    datefmt="%H:%M:%S", stream=sys.stderr)
+log = logging.getLogger("ingest")
+
+DSN = sys.argv[1]
+WHAT = sys.argv[2] if len(sys.argv) > 2 else "all"
+ARCHIVE = os.path.expanduser("~/dal-archive/phoenix-2026-08-03")
+PROJECTS = os.path.expanduser("~/.claude/projects")
+TICKET_RE = re.compile(r"\b(?:ENG2?|CWORK|GTM)-\d+\b")
+
+DDL = """
+CREATE SCHEMA IF NOT EXISTS dal_catalog;
+CREATE TABLE IF NOT EXISTS dal_catalog.sessions (
+  session_id  text PRIMARY KEY,
+  sources     text[] NOT NULL,
+  account_uuid text,
+  device_id   text,
+  project_path text,
+  started_at  timestamptz,
+  ended_at    timestamptz,
+  n_llm_calls int,
+  n_user_turns int,
+  n_tool_calls int,
+  models      text[],
+  tools_top   jsonb,
+  git_branch  text,
+  first_user_prompt text,
+  summary     text,
+  category    text,
+  tickets     text[],
+  rollout     jsonb,
+  meta        jsonb,
+  ingested_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS sessions_started_idx ON dal_catalog.sessions (started_at);
+CREATE INDEX IF NOT EXISTS sessions_category_idx ON dal_catalog.sessions (category);
+"""
+
+UPSERT = """
+INSERT INTO dal_catalog.sessions AS s
+  (session_id, sources, account_uuid, device_id, project_path, started_at, ended_at,
+   n_llm_calls, n_user_turns, n_tool_calls, models, tools_top, git_branch,
+   first_user_prompt, tickets, rollout, meta)
+VALUES (%(session_id)s, %(sources)s, %(account_uuid)s, %(device_id)s, %(project_path)s,
+        %(started_at)s, %(ended_at)s, %(n_llm_calls)s, %(n_user_turns)s, %(n_tool_calls)s,
+        %(models)s, %(tools_top)s, %(git_branch)s, %(first_user_prompt)s, %(tickets)s,
+        %(rollout)s, %(meta)s)
+ON CONFLICT (session_id) DO UPDATE SET
+  sources = (SELECT array_agg(DISTINCT x) FROM unnest(s.sources || excluded.sources) x),
+  account_uuid = COALESCE(excluded.account_uuid, s.account_uuid),
+  device_id = COALESCE(excluded.device_id, s.device_id),
+  project_path = COALESCE(excluded.project_path, s.project_path),
+  started_at = LEAST(s.started_at, excluded.started_at),
+  ended_at = GREATEST(s.ended_at, excluded.ended_at),
+  n_llm_calls = GREATEST(coalesce(s.n_llm_calls,0), coalesce(excluded.n_llm_calls,0)),
+  n_user_turns = COALESCE(excluded.n_user_turns, s.n_user_turns),
+  n_tool_calls = COALESCE(excluded.n_tool_calls, s.n_tool_calls),
+  models = COALESCE(excluded.models, s.models),
+  tools_top = COALESCE(excluded.tools_top, s.tools_top),
+  git_branch = COALESCE(excluded.git_branch, s.git_branch),
+  first_user_prompt = COALESCE(excluded.first_user_prompt, s.first_user_prompt),
+  tickets = COALESCE(excluded.tickets, s.tickets),
+  rollout = COALESCE(excluded.rollout, s.rollout),
+  meta = coalesce(s.meta, '{}'::jsonb) || coalesce(excluded.meta, '{}'::jsonb)
+"""
+
+BASE = dict(account_uuid=None, device_id=None, project_path=None, started_at=None,
+            ended_at=None, n_llm_calls=None, n_user_turns=None, n_tool_calls=None,
+            models=None, tools_top=None, git_branch=None, first_user_prompt=None,
+            tickets=None, rollout=None, meta=None)
+
+
+def upsert_many(conn, rows):
+    with conn.cursor() as cur:
+        for r in rows:
+            cur.execute(UPSERT, {**BASE, **r})
+    conn.commit()
+
+
+def ingest_archive(conn):
+    t0 = time.perf_counter()
+    log.info("[archive] aggregating litellm_request spans by session tag")
+    db = duckdb.connect()
+    rows = db.execute(f"""
+        WITH raw AS (
+          SELECT json_extract_string(attributes, '$.metadata.user_api_key_end_user_id') AS eu,
+                 json_extract_string(attributes, '$.llm.model_name') AS model,
+                 start_time, end_time
+          FROM read_parquet('{ARCHIVE}/spans_*.parquet') WHERE name = 'litellm_request'),
+        p AS (
+          SELECT CASE WHEN json_valid(eu) THEN json_extract_string(eu, '$.session_id') END AS sid,
+                 CASE WHEN json_valid(eu) THEN json_extract_string(eu, '$.account_uuid') END AS acct,
+                 CASE WHEN json_valid(eu) THEN json_extract_string(eu, '$.device_id') ELSE eu END AS dev,
+                 model, start_time, end_time
+          FROM raw)
+        SELECT sid, any_value(acct), any_value(dev), min(start_time), max(end_time),
+               count(*), list_distinct(list(model))
+        FROM p WHERE sid IS NOT NULL GROUP BY sid
+    """).fetchall()
+    log.info("[archive] %d sessions aggregated in %.1fs", len(rows), time.perf_counter() - t0)
+    payload = [dict(session_id=sid, sources=["phoenix_archive"], account_uuid=acct,
+                    device_id=dev, started_at=st, ended_at=en, n_llm_calls=n,
+                    models=[m for m in (models or []) if m])
+               for sid, acct, dev, st, en, n, models in rows]
+    upsert_many(conn, payload)
+    log.info("[archive] upserted %d rows in %.1fs total", len(payload), time.perf_counter() - t0)
+
+
+def ingest_rollouts(conn):
+    t0 = time.perf_counter()
+    with conn.cursor() as cur:
+        cur.execute("""SELECT table_schema FROM information_schema.tables
+                       WHERE table_name='sandbox_agent_sessions' AND table_schema LIKE 'workspace%'""")
+        schemas = [r[0] for r in cur.fetchall()]
+        wanted = ["id", "agent", "sandbox_id", "mode", "started_at", "ended_at", "stop_reason",
+                  "pr_url", "rollout_id", "label_tier", "seed_name", "parent_session_id"]
+        payload = []
+        for sc in schemas:
+            cur.execute("""SELECT column_name FROM information_schema.columns
+                           WHERE table_schema=%s AND table_name='sandbox_agent_sessions'""", (sc,))
+            have = {r[0] for r in cur.fetchall()}
+            cols = [c for c in wanted if c in have]
+            cur.execute(f'SELECT {", ".join(cols)} FROM "{sc}".sandbox_agent_sessions')
+            for row in cur.fetchall():
+                d = dict(zip(cols, row))
+                payload.append(dict(
+                    session_id=d["id"], sources=["sandbox_rollout"],
+                    started_at=d.get("started_at"), ended_at=d.get("ended_at"),
+                    project_path=f"workspace:{sc.removeprefix('workspace_')}",
+                    rollout=Jsonb({"schema": sc, **{k: str(v) if v is not None else None
+                                                    for k, v in d.items()
+                                                    if k not in ("id", "started_at", "ended_at")}})))
+    upsert_many(conn, payload)
+    log.info("[rollouts] upserted %d rows from %d schemas in %.1fs",
+             len(payload), len(schemas), time.perf_counter() - t0)
+
+
+SKIP_PROMPT_PREFIXES = ("<command-name>", "<local-command-stdout", "Caveat:",
+                        "<system-reminder>", "[Request interrupted")
+
+
+def parse_jsonl(path):
+    sid = Path(path).stem
+    first_ts = last_ts = cwd = branch = version = None
+    n_user = n_tools = 0
+    tools = Counter()
+    models = set()
+    first_prompt = None
+    texts = []
+    with open(path, errors="replace") as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            ts = rec.get("timestamp")
+            if ts:
+                first_ts = first_ts or ts
+                last_ts = ts
+            cwd = cwd or rec.get("cwd")
+            branch = branch or rec.get("gitBranch")
+            version = version or rec.get("version")
+            msg = rec.get("message") or {}
+            if rec.get("type") == "user" and not rec.get("isMeta"):
+                content = msg.get("content")
+                if isinstance(content, str):
+                    txt = content.strip()
+                elif isinstance(content, list):
+                    txt = " ".join(c.get("text", "") for c in content
+                                   if isinstance(c, dict) and c.get("type") == "text").strip()
+                else:
+                    txt = ""
+                if txt and not txt.startswith(SKIP_PROMPT_PREFIXES):
+                    n_user += 1
+                    texts.append(txt[:2000])
+                    if first_prompt is None:
+                        first_prompt = txt[:1500]
+            elif rec.get("type") == "assistant":
+                if msg.get("model"):
+                    models.add(msg["model"])
+                for c in msg.get("content") or []:
+                    if isinstance(c, dict) and c.get("type") == "tool_use":
+                        n_tools += 1
+                        tools[c.get("name", "?")] += 1
+    tickets = sorted(set(TICKET_RE.findall(" ".join(texts[:50]))))
+    return dict(
+        session_id=sid, sources=["local_jsonl"], project_path=cwd,
+        started_at=first_ts, ended_at=last_ts, n_user_turns=n_user, n_tool_calls=n_tools,
+        models=sorted(models) or None, tools_top=Jsonb(dict(tools.most_common(8))),
+        git_branch=branch, first_user_prompt=first_prompt, tickets=tickets or None,
+        meta=Jsonb({"machine": "adam-mac", "claude_version": version}))
+
+
+def ingest_local(conn):
+    t0 = time.perf_counter()
+    # teraflop work only — personal/non-teraflop projects are deliberately excluded
+    files = [p for p in glob.glob(f"{PROJECTS}/-Users-vanities-git-work-teraflop*/*.jsonl")
+             if not Path(p).name.startswith("agent-")]
+    payload, errors = [], 0
+    for p in files:
+        try:
+            payload.append(parse_jsonl(p))
+        except Exception as e:
+            errors += 1
+            log.warning("[local] failed %s: %s", p, str(e)[:120])
+    upsert_many(conn, payload)
+    log.info("[local] upserted %d of %d files (%d errors) in %.1fs",
+             len(payload), len(files), errors, time.perf_counter() - t0)
+
+
+def main():
+    with psycopg.connect(DSN, connect_timeout=15) as conn:
+        with conn.cursor() as cur:
+            cur.execute(DDL)
+        conn.commit()
+        log.info("schema ready")
+        if WHAT in ("archive", "all"):
+            ingest_archive(conn)
+        if WHAT in ("rollouts", "all"):
+            ingest_rollouts(conn)
+        if WHAT in ("local", "all"):
+            ingest_local(conn)
+        with conn.cursor() as cur:
+            cur.execute("""SELECT unnest(sources) src, count(*) FROM dal_catalog.sessions
+                           GROUP BY 1 ORDER BY 2 DESC""")
+            print("\n=== catalog by source ===")
+            for src, n in cur.fetchall():
+                print(f"  {src}: {n}")
+            cur.execute("SELECT count(*), min(started_at), max(started_at) FROM dal_catalog.sessions")
+            print("total / range:", cur.fetchone())
+
+
+main()

--- a/scripts/dal_catalog/extract_content.py
+++ b/scripts/dal_catalog/extract_content.py
@@ -1,0 +1,137 @@
+"""ENG2-1470 phase 2a: extract a content sample per cataloged session, for
+LLM categorization. Writes one JSON per session to ./session_samples/.
+
+Sample = {session_id, who, project_path, started_at, n_llm_calls, first_prompt,
+          last_output, rollout_task}
+Sources in priority order: local JSONL (already has first_user_prompt in the
+catalog), sandbox_agent_events (rollout task prompt), parquet archive
+(earliest litellm span's first message + latest span's output).
+"""
+
+import ast
+import json
+import logging
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+import duckdb
+import psycopg
+
+logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(message)s",
+                    datefmt="%H:%M:%S", stream=sys.stderr)
+log = logging.getLogger("extract")
+
+DSN = sys.argv[1]
+ARCHIVE = os.path.expanduser("~/dal-archive/phoenix-2026-08-03")
+OUT = Path(__file__).parent / "session_samples"
+OUT.mkdir(exist_ok=True)
+
+
+def parse_convo(s):
+    """input.value / message content — python-repr or json list of messages."""
+    for loader in (json.loads, ast.literal_eval):
+        try:
+            v = loader(s)
+            if isinstance(v, dict) and "messages" in v:
+                v = v["messages"]
+            if isinstance(v, list):
+                return v
+        except Exception:
+            continue
+    return None
+
+
+def first_text(convo):
+    for m in convo or []:
+        if not isinstance(m, dict) or m.get("role") not in (None, "user"):
+            continue
+        c = m.get("content")
+        if isinstance(c, str) and c.strip():
+            return c.strip()[:1500]
+        if isinstance(c, list):
+            for part in c:
+                if isinstance(part, dict) and part.get("type") == "text" and part.get("text", "").strip():
+                    return part["text"].strip()[:1500]
+    return None
+
+
+def main():
+    t0 = time.perf_counter()
+    with psycopg.connect(DSN, connect_timeout=15) as conn, conn.cursor() as cur:
+        cur.execute("""
+            SELECT s.session_id, coalesce(a.name, nullif(s.account_uuid,''), 'unknown'),
+                   s.project_path, s.started_at::text, s.n_llm_calls, s.sources,
+                   s.first_user_prompt, s.rollout
+            FROM dal_catalog.sessions s
+            LEFT JOIN dal_catalog.accounts a USING (account_uuid)
+        """)
+        sessions = {r[0]: dict(session_id=r[0], who=r[1], project_path=r[2],
+                               started_at=r[3], n_llm_calls=r[4], sources=r[5],
+                               first_prompt=r[6], rollout_task=None, last_output=None)
+                    for r in cur.fetchall()}
+        log.info("[extract] %d catalog sessions loaded", len(sessions))
+
+        # rollout task prompts from sandbox_agent_events (first user/prompt event)
+        cur.execute("""SELECT table_schema FROM information_schema.tables
+                       WHERE table_name='sandbox_agent_events' AND table_schema LIKE 'workspace%'""")
+        for (sc,) in cur.fetchall():
+            try:
+                cur.execute(f'''
+                    SELECT session_id, payload::text FROM "{sc}".sandbox_agent_events
+                    WHERE kind IN ('prompt','user_message','session_prompt')
+                       OR payload::text ILIKE '%"prompt"%'
+                    ORDER BY session_id, seq LIMIT 500''')
+                for sid, payload in cur.fetchall():
+                    s = sessions.get(sid)
+                    if s is not None and not s["rollout_task"]:
+                        m = re.search(r'"(?:prompt|text|content)"\s*:\s*"(.{20,1200}?)(?<!\\)"', payload)
+                        if m:
+                            s["rollout_task"] = m.group(1)[:1200]
+            except Exception as e:
+                conn.rollback()
+                log.warning("[extract] %s events: %s", sc, str(e)[:100])
+
+    # archive: earliest litellm span input + latest output per session
+    need = [sid for sid, s in sessions.items()
+            if not s["first_prompt"] and not s["rollout_task"] and "phoenix_archive" in (s["sources"] or [])]
+    log.info("[extract] pulling archive content for %d sessions", len(need))
+    db = duckdb.connect()
+    rows = db.execute(f"""
+        WITH lit AS (
+          SELECT CASE WHEN json_valid(json_extract_string(attributes, '$.metadata.user_api_key_end_user_id'))
+                      THEN json_extract_string(json_extract_string(attributes, '$.metadata.user_api_key_end_user_id'), '$.session_id') END AS sid,
+                 start_time,
+                 json_extract_string(attributes, '$.input.value') AS input_value,
+                 json_extract_string(attributes, '$.output.value') AS output_value
+          FROM read_parquet('{ARCHIVE}/spans_*.parquet') WHERE name = 'litellm_request')
+        SELECT sid,
+               min_by(input_value, start_time) AS first_input,
+               max_by(output_value, start_time) AS last_output
+        FROM lit WHERE sid IS NOT NULL GROUP BY sid
+    """).fetchall()
+    log.info("[extract] archive aggregation done in %.0fs", time.perf_counter() - t0)
+    hit = 0
+    for sid, first_input, last_output in rows:
+        s = sessions.get(sid)
+        if s is None:
+            continue
+        if not s["first_prompt"] and isinstance(first_input, str):
+            s["first_prompt"] = first_text(parse_convo(first_input)) or first_input[:800]
+            hit += 1
+        if isinstance(last_output, str) and last_output.strip():
+            s["last_output"] = last_output.strip()[:800]
+
+    n = 0
+    for sid, s in sessions.items():
+        (OUT / f"{sid}.json").write_text(json.dumps(s, default=str))
+        n += 1
+    with_content = sum(1 for s in sessions.values()
+                       if s["first_prompt"] or s["rollout_task"] or s["last_output"])
+    print(f"wrote {n} samples ({with_content} with content, archive fills: {hit}) "
+          f"in {time.perf_counter() - t0:.0f}s -> {OUT}")
+
+
+main()


### PR DESCRIPTION
## What

`scripts/dal_catalog/` — the re-runnable pipeline behind `dal_catalog.sessions` in the shared Supabase: every historical DAL/Claude session (May 6 → Aug 4, cross-machine) with person attribution, usage category, and one-line summary. Built for the DAL 2.0 usage analysis (ENG2-1470 → ENG2-1471).

## Pipeline

1. `catalog_ingest.py` — merges three sources by session_id: parquet-archive litellm session tags (1,267 sessions), `workspace_*.sandbox_agent_sessions` (115), local teraflop JSONLs (52; personal projects excluded by design)
2. `extract_content.py` — per-session content sample (first prompt / rollout task / last output); 98.7% coverage
3. 14 parallel Claude subagents categorize against a seeded+emergent taxonomy
4. `apply_categories.py` — writes category/summary back; emergent labels normalized

## First-run results (2026-08-04)

1,333 sessions, 0 uncategorized. Top categories: ir-eval 419 (31%), noise 324 (24%), customer-work 103, workspace-rollout-infra 94, ticket-implementation 67. Tagged-person split: Alex 257, Will 91, Adam 72, Yash 20 (550 non-noise sessions untagged — rollout VMs have no account identity; known gap).

Details + design decisions (personal-path exclusion, untagged-call exclusion, one-shot lifecycle): ENG2-1470.

https://claude.ai/code/session_01CPCBEjaneDDB7zYZkTYFHb