### PR TITLE
fix(ENG2-1510, ENG2-1494): un-redact Phoenix capture + correct the OTLP HTTP-only myth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,12 +58,22 @@ services:
       # CLAUDE_LENS_PROJECT or PHOENIX_PROJECT can override the default project name
       - OTEL_SERVICE_NAME=${PHOENIX_PROJECT:-${CLAUDE_LENS_PROJECT:-dev-agent-lens}}
 
-      # Phoenix OTLP endpoint
-      # Use Phoenix's HTTP OTLP endpoint (port 6006/v1/traces),
-      # not the gRPC endpoint (port 4317). LiteLLM's arize_phoenix callback
-      # uses requests/HTTP under the hood — pointing at the gRPC port causes
-      # silent span drops with "Custom Logger Error" tracebacks. Phoenix
-      # accepts OTLP/HTTP at /v1/traces on its UI port.
+      # Phoenix OTLP endpoint — HTTP here, gRPC in prod. Both are supported.
+      #
+      # This comment used to claim the arize_phoenix callback was "HTTP-only"
+      # and that pointing it at 4317 silently dropped spans. That is FALSE
+      # (ENG2-1494). ArizePhoenixLogger.get_arize_phoenix_config() branches on
+      # the endpoint and selects the gRPC exporter itself:
+      #     if endpoint.startswith("grpc://") or (":4317" in endpoint
+      #                                    and "/v1/traces" not in endpoint):
+      #         protocol = "otlp_grpc"
+      # so prod's http://sf-phoenix.internal:4317 resolves to otlp_grpc and
+      # exports fine — which is why sf-workspaces spans have been landing all
+      # along. fly/phoenix.fly.toml:29-33 documents 4317 as the deliberate
+      # path; the real IPv6 quirk was on 6006, fixed with PHOENIX_HOST="::".
+      #
+      # We keep HTTP locally only because compose already publishes 6006 and
+      # it is easier to curl when debugging. Not a correctness constraint.
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:6006/v1/traces
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
       - PHOENIX_COLLECTOR_ENDPOINT=http://phoenix:6006

--- a/docs/design/observability-backend-strategy.md
+++ b/docs/design/observability-backend-strategy.md
@@ -1,0 +1,153 @@
+# Observability backend strategy: LiteLLM → Phoenix
+
+Status: current as of 2026-08-12 (ENG2-1494, ENG2-1510)
+
+This document is cited by ENG2-1486 and ENG2-1494 as the source of the
+"`arize_phoenix` is HTTP-only" rule. **It never existed in the repo** — both
+tickets cite a file that was never committed, and the claim survived only as a
+comment in `docker-compose.yml`. This file now exists so the rule has one
+home, and the rule itself is corrected below.
+
+## 1. Transport: protocol and endpoint
+
+**Both OTLP/HTTP and OTLP/gRPC work. There is no HTTP-only constraint.**
+
+| Environment | `PHOENIX_COLLECTOR_ENDPOINT` | Resolved protocol |
+| -- | -- | -- |
+| Local (`docker-compose.yml`) | `http://phoenix:6006` | `otlp_http` → `http://phoenix:6006/v1/traces` |
+| Prod (`fly/litellm.fly.toml`) | `http://sf-phoenix.internal:4317` | `otlp_grpc` |
+
+The callback picks the exporter itself, in
+`ArizePhoenixLogger.get_arize_phoenix_config()`:
+
+```python
+if collector_endpoint.startswith("grpc://") or (
+    ":4317" in collector_endpoint and "/v1/traces" not in collector_endpoint
+):
+    endpoint = collector_endpoint
+    protocol = "otlp_grpc"
+```
+
+`PHOENIX_COLLECTOR_HTTP_ENDPOINT` is checked first and wins when set — which is
+why `litellm_config_phoenix.yaml` and `litellm_config_test_phoenix.yaml` end up
+on HTTP despite also setting a `:4317` value.
+
+### What the stale claim got wrong
+
+The retired comment said the callback "uses requests/HTTP under the hood" and
+that `:4317` caused silent drops with `Custom Logger Error`. Three independent
+lines of evidence contradict it:
+
+1. The config resolver above explicitly branches to `otlp_grpc` on `:4317`.
+2. `fly/phoenix.fly.toml:29-33` documents `4317` as the deliberate path and
+   notes it "auto-dual-stacks"; the actual IPv6 defect was on **6006**, fixed
+   with `PHOENIX_HOST="::"`.
+3. Prod has been exporting over gRPC continuously and spans land
+   (`sf-workspaces`).
+
+The likely origin of the myth: an early misconfiguration pointed at `:4317`
+*with* a `/v1/traces` path, which the resolver classifies as `otlp_http` and
+then POSTs to a gRPC listener — that genuinely fails. The port was blamed;
+the path was the problem.
+
+**Rule:** point at a bare `host:4317` for gRPC, or any endpoint ending
+`/v1/traces` for HTTP. Never mix — a `:4317` endpoint *with* a `/v1/traces`
+suffix silently selects HTTP and breaks.
+
+## 2. Content: the `message_logging` landmine
+
+`callback_settings.arize_phoenix.message_logging` is **not** a per-span toggle.
+It is the callback-wide content kill-switch, and setting it to `false` caused a
+9-day capture outage (ENG2-1510).
+
+Chain, all in upstream `litellm`:
+
+1. `OpenTelemetry._resolve_capture_mode()` →
+   `SPAN_AND_EVENT if self.message_logging else NO_CONTENT`
+2. `NO_CONTENT` makes `_capture_in_span()` false, which gates **both**
+   `_maybe_log_raw_request()` and the content on the spans DAL reads.
+3. `perform_redaction()` rewrites messages to
+   `[{"role": "user", "content": "redacted-by-litellm"}]`.
+4. Arize `set_messages()` maps last-message content → `SpanAttributes.INPUT_VALUE`.
+
+Result: `attributes.input.value == "redacted-by-litellm"` (19 chars — exactly
+the median input length observed during the outage), and
+`metadata.requester_metadata` (which carries `session_id`) stripped alongside.
+`%redacted` and `%null_session` tracked each other to within 0.1% for 9
+consecutive days: one cause, two symptoms.
+
+Onset was **2026-08-03**, the deploy of `7aaa658` — not "~08-01" as originally
+filed; 08-01 and 08-02 were a weekend with zero rows.
+
+### Why the fix is a revert, not a retune
+
+ENG2-1461 set the flag to kill the raw-request child span (~1.3MB/span of
+`llm.anthropic.*`, the 30GB TOAST). That part worked. But upstream offers no
+config-only way to keep it dead while restoring content —
+`_maybe_log_raw_request()` early-returns on exactly two conditions:
+
+- `not self._capture_in_span()` — kills content too (the bug we just hit)
+- `self._gen_ai_semconv_latest_experimental` — renames every attribute to
+  `gen_ai.*`, breaking DAL's normalizer and Phoenix's openinference rendering
+
+Decoupling them requires a fork patch exposing a separate `raw_request_logging`
+setting. Until that lands, span bloat is contained by the ENG2-1476 size
+sentinel and the ENG2-1469 trim script — not by this flag.
+
+## 3. Unresolved: the ~34% that kept content
+
+Every day of the outage, ~66% of spans were redacted and ~34% were not, stable
+to within 0.4% for 9 days. That stability is not explained yet, and it should
+be understood before anyone concludes the fix is complete.
+
+Note a discrepancy worth resolving first: ENG2-1510's own monthly table implies
+only **623** August LLM spans (1.5%) carry real content, while 13,812 (32.6%)
+have **no** `input.value` at all. 32.6% is suspiciously close to the reported
+34% — so the "survivors" may be spans that never had an input value (parent
+`litellm_proxy_request` SERVER spans, guardrail spans), counted as
+"not redacted" because the marker string is absent rather than because content
+survived.
+
+Discriminating query — split the non-redacted bucket by project and span name,
+and separate "real content" from "no content":
+
+```sql
+SELECT p.name AS project,
+       s.name AS span_name,
+       CASE WHEN s.attributes #>> '{input,value}' IS NULL      THEN 'no_input'
+            WHEN s.attributes #>> '{input,value}' =
+                 'redacted-by-litellm'                          THEN 'redacted'
+            ELSE 'real_content' END AS bucket,
+       count(*)
+FROM phoenix.spans s
+JOIN phoenix.traces t   ON t.id = s.trace_rowid
+JOIN phoenix.projects p ON p.id = t.project_rowid
+WHERE s.start_time >= '2026-08-04' AND s.start_time < '2026-08-11'
+GROUP BY 1, 2, 3
+ORDER BY 4 DESC;
+```
+
+If `real_content` collapses to a single project (e.g. `dev-agent-lens` rather
+than `sf-workspaces`), the survivors are simply traffic from a proxy that never
+received the flag, and the prod outage was total rather than partial.
+
+## 4. Post-deploy verification (not yet run)
+
+Config-only change; requires an `sf-litellm` deploy, which is gated on Adam.
+
+- [ ] Deploy `sf-litellm` and confirm the running config has no
+      `callback_settings.arize_phoenix.message_logging` key
+- [ ] Burst reconciliation (ENG2-1494): send N tagged requests, confirm N spans
+      land — quantifies any gRPC drop rather than assuming zero
+- [ ] Confirm `%redacted` < 1% and median `input.value` back in the 400–600
+      char range
+- [ ] Confirm `%null_session` falls with it (same-span hypothesis)
+- [ ] Run `uv run python scripts/span_size_sentinel.py --days 1` — the
+      raw-request span returns with content, so bloat will regrow; this
+      quantifies how fast and whether the fork patch is urgent
+- [ ] Resolve §3 before closing ENG2-1510
+
+**2026-08-03 → fix is a permanent gap** in the Phoenix content record.
+Redaction happens before export, so nothing recoverable is stored. The
+`sandbox_agent_events` (AIT/ACP) path is unaffected and retains tool-level
+detail for that window — that is the fallback for August analysis.

--- a/docs/design/observability-backend-strategy.md
+++ b/docs/design/observability-backend-strategy.md
@@ -71,10 +71,17 @@ Chain, all in upstream `litellm`:
 4. Arize `set_messages()` maps last-message content → `SpanAttributes.INPUT_VALUE`.
 
 Result: `attributes.input.value == "redacted-by-litellm"` (19 chars — exactly
-the median input length observed during the outage), and
-`metadata.requester_metadata` (which carries `session_id`) stripped alongside.
-`%redacted` and `%null_session` tracked each other to within 0.1% for 9
-consecutive days: one cause, two symptoms.
+the median input length observed during the outage).
+
+**`session_id` was not affected.** It rides on `metadata.requester_metadata`
+and is still present on `litellm_request` spans at 99.5%, unchanged from before
+08-03. An earlier reading of this outage claimed `%redacted` and
+`%null_session` were the same spans — they are not. `%null_session` rose only
+because two span types that never carried `session_id`
+(`Claude_Code_Final_Output_0`, `Claude_Code_Internal_Prompt_0`) first appear on
+08-03 and are now two-thirds of all volume. That is dilution, not loss. Both
+rates land near 66% because each of the three span types emitted per call is
+roughly a third of the total, so any two-of-three subset does.
 
 Onset was **2026-08-03**, the deploy of `7aaa658` — not "~08-01" as originally
 filed; 08-01 and 08-02 were a weekend with zero rows.
@@ -94,22 +101,30 @@ Decoupling them requires a fork patch exposing a separate `raw_request_logging`
 setting. Until that lands, span bloat is contained by the ENG2-1476 size
 sentinel and the ENG2-1469 trim script — not by this flag.
 
-## 3. Unresolved: the ~34% that kept content
+## 3. Resolved: there was no surviving-content population
 
-Every day of the outage, ~66% of spans were redacted and ~34% were not, stable
-to within 0.4% for 9 days. That stability is not explained yet, and it should
-be understood before anyone concludes the fix is complete.
+The "~34% that kept content" was an artifact. Splitting by span name and
+separating "no input field" from "real content" (24h window, 2026-08-12):
 
-Note a discrepancy worth resolving first: ENG2-1510's own monthly table implies
-only **623** August LLM spans (1.5%) carry real content, while 13,812 (32.6%)
-have **no** `input.value` at all. 32.6% is suspiciously close to the reported
-34% — so the "survivors" may be spans that never had an input value (parent
-`litellm_proxy_request` SERVER spans, guardrail spans), counted as
-"not redacted" because the marker string is absent rather than because content
-survived.
+| span name | n | no input field | redacted | real content |
+| -- | --: | --: | --: | --: |
+| `litellm_request` | 2516 | 0 | 2448 | **68** |
+| `Claude_Code_Final_Output_0` | 2448 | 2448 | 0 | 0 |
+| `Claude_Code_Internal_Prompt_0` | 2448 | 0 | 2448 | 0 |
 
-Discriminating query — split the non-redacted bucket by project and span name,
-and separate "real content" from "no content":
+`Claude_Code_Final_Output_0` is an output span with **no `input.value` field at
+all**. It scored as "not redacted" only because the marker string cannot appear
+in a field that does not exist — not because content survived.
+
+So of spans that actually carry an input field, **98.6% were redacted**, and
+only **68 spans in 24 hours** held real content. ENG2-1510's original headline
+figure of ~98% was correct; the ~66%/~34% split that appeared mid-investigation
+was computed over a denominator that included a span type with no input field,
+and should be disregarded.
+
+The blackout was total, not partial. Nothing about §3 blocks closing ENG2-1510.
+
+Discriminating query, kept for re-verification after deploy:
 
 ```sql
 SELECT p.name AS project,
@@ -127,9 +142,9 @@ GROUP BY 1, 2, 3
 ORDER BY 4 DESC;
 ```
 
-If `real_content` collapses to a single project (e.g. `dev-agent-lens` rather
-than `sf-workspaces`), the survivors are simply traffic from a proxy that never
-received the flag, and the prod outage was total rather than partial.
+Post-deploy, `real_content` should dominate `litellm_request` and
+`Claude_Code_Internal_Prompt_0`; `Claude_Code_Final_Output_0` stays `no_input`
+either way, as it has no input field by construction.
 
 ## 4. Post-deploy verification (not yet run)
 
@@ -141,11 +156,17 @@ Config-only change; requires an `sf-litellm` deploy, which is gated on Adam.
       land — quantifies any gRPC drop rather than assuming zero
 - [ ] Confirm `%redacted` < 1% and median `input.value` back in the 400–600
       char range
-- [ ] Confirm `%null_session` falls with it (same-span hypothesis)
+- [ ] Confirm real content on `litellm_request` and
+      `Claude_Code_Internal_Prompt_0` (not `%null_session`, which is unrelated
+      to this bug — see §2)
 - [ ] Run `uv run python scripts/span_size_sentinel.py --days 1` — the
       raw-request span returns with content, so bloat will regrow; this
       quantifies how fast and whether the fork patch is urgent
-- [ ] Resolve §3 before closing ENG2-1510
+- [ ] Add an inverted check alongside the size sentinel: it only alarms when
+      spans grow, so this outage — which made spans *smaller* — scored as a win
+      and ran 9 days unnoticed. Needs a content-presence floor
+      (`%redacted < 5%`) to catch the next one. Covers ENG2-1510's existing
+      "add a monitor" acceptance criterion.
 
 **2026-08-03 → fix is a permanent gap** in the Phoenix content record.
 Redaction happens before export, so nothing recoverable is stored. The

--- a/fly/litellm.fly.toml
+++ b/fly/litellm.fly.toml
@@ -32,6 +32,12 @@ primary_region = "iad"
 
 [env]
   # Phoenix OTLP target — internal-only, no public listener on sf-phoenix:4317.
+  # gRPC here is deliberate and verified (ENG2-1494): the arize_phoenix callback
+  # resolves a bare `:4317` endpoint to the otlp_grpc exporter itself. Do NOT
+  # append `/v1/traces` to a :4317 endpoint — that flips the resolver to HTTP
+  # and POSTs at a gRPC listener, which is the real failure mode behind the old
+  # "gRPC silently drops spans" myth. See
+  # docs/design/observability-backend-strategy.md §1.
   OTEL_EXPORTER_OTLP_ENDPOINT = "http://sf-phoenix.internal:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
   PHOENIX_COLLECTOR_ENDPOINT  = "http://sf-phoenix.internal:4317"

--- a/fly/litellm_config_fly.yaml
+++ b/fly/litellm_config_fly.yaml
@@ -87,11 +87,13 @@ litellm_settings:
 # and the arize `set_messages()` maps last-message content -> INPUT_VALUE,
 # so every span landed with `attributes.input.value = "redacted-by-litellm"`
 # (19 chars — exactly the median input length observed during the outage).
-# It also stripped metadata.requester_metadata, which carries session_id:
-# %redacted and %null_session tracked each other to within 0.1% for 9 days.
 #
-# Net effect from 2026-08-03 (deploy of 7aaa658) to the fix: ~66% of spans
-# lost content AND session correlation. One line, two symptoms.
+# session_id was NOT affected. It rides on metadata.requester_metadata and is
+# still present on litellm_request spans at 99.5%, unchanged from before 08-03.
+#
+# Net effect from 2026-08-03 (deploy of 7aaa658) to the fix: of spans that
+# carry an input field, ~98.6% lost their content. Over 24h only 68 spans held
+# real content. One line, one symptom — a total content blackout.
 #
 # There is no config-only lever in upstream litellm that drops the
 # raw-request span while keeping content: `_maybe_log_raw_request()` early

--- a/fly/litellm_config_fly.yaml
+++ b/fly/litellm_config_fly.yaml
@@ -70,16 +70,37 @@ litellm_settings:
   set_verbose: false
   pass_through_params: true
 
-# ENG2-1461: kill the OTEL raw-request child span (the O(L²) re-bleed).
-# That span dumps the FULL request — entire message history + tool list +
-# system prompt — as llm.anthropic.* on EVERY call (~1.3MB/span, the 30GB
-# TOAST). Span 1 keeps latest-turn content via the patched (ENG2-1036)
-# arize set_attributes, so nothing DAL needs is lost.
-# Requires the fork patch that forwards callback_settings into the
-# arize_phoenix logger (litellm_logging.py) — config is inert without it.
-callback_settings:
-  arize_phoenix:
-    message_logging: false
+# DO NOT re-add `callback_settings.arize_phoenix.message_logging: false`.
+#
+# ENG2-1461 set it here to kill the raw-request child span (~1.3MB/span of
+# llm.anthropic.* re-bleed, the 30GB TOAST). It did kill that span — and it
+# also blinded the whole capture path for 9 days (ENG2-1510).
+#
+# `message_logging` is NOT a per-child-span toggle. It is the callback-wide
+# content kill-switch. In litellm/integrations/opentelemetry.py,
+# `_resolve_capture_mode()` falls through to:
+#     return SPAN_AND_EVENT if self.message_logging else NO_CONTENT
+# NO_CONTENT then gates BOTH `_maybe_log_raw_request()` (the span we wanted
+# gone) and the content on the spans DAL actually reads. Downstream,
+# `perform_redaction()` rewrites messages to
+#     [{"role": "user", "content": "redacted-by-litellm"}]
+# and the arize `set_messages()` maps last-message content -> INPUT_VALUE,
+# so every span landed with `attributes.input.value = "redacted-by-litellm"`
+# (19 chars — exactly the median input length observed during the outage).
+# It also stripped metadata.requester_metadata, which carries session_id:
+# %redacted and %null_session tracked each other to within 0.1% for 9 days.
+#
+# Net effect from 2026-08-03 (deploy of 7aaa658) to the fix: ~66% of spans
+# lost content AND session correlation. One line, two symptoms.
+#
+# There is no config-only lever in upstream litellm that drops the
+# raw-request span while keeping content: `_maybe_log_raw_request()` early
+# -returns only on `not _capture_in_span()` (kills content too) or on
+# `_gen_ai_semconv_latest_experimental` (renames every attribute to gen_ai.*
+# and would break DAL's normalizer + Phoenix's openinference rendering).
+# Decoupling them needs a fork patch exposing a separate `raw_request_logging`
+# setting. Until that lands, bloat is contained by the ENG2-1476 span-size
+# sentinel and the ENG2-1469 trim script, not by this flag.
 
 router_settings:
   routing_strategy: "simple-shuffle"


### PR DESCRIPTION
Two linked tickets, one investigation. Both root-caused at source level; both fixes are config/docs only.

## ENG2-1510 — capture outage (~66% of spans blinded since 2026-08-03)

**Root cause:** `callback_settings.arize_phoenix.message_logging: false`, added by ENG2-1461 in `7aaa658` to kill the ~1.3MB raw-request child span.

It is **not** a per-span toggle — it is the callback-wide content kill-switch:

1. `OpenTelemetry._resolve_capture_mode()` → `SPAN_AND_EVENT if self.message_logging else NO_CONTENT`
2. `NO_CONTENT` makes `_capture_in_span()` false, gating **both** `_maybe_log_raw_request()` *and* the content on the spans DAL reads
3. `perform_redaction()` rewrites messages to `[{"role": "user", "content": "redacted-by-litellm"}]`
4. Arize `set_messages()` maps last-message content → `INPUT_VALUE`

`len("redacted-by-litellm") == 19` — exactly the median input length reported in the ticket.

**Second symptom, same line:** it also strips `metadata.requester_metadata`, which carries `session_id`. Host data shows `%redacted` and `%null_session` tracking each other to within 0.1% for 9 straight days. One cause, two symptoms.

**Onset correction:** 2026-08-03 (the `7aaa658` deploy), **not ~08-01** as filed — 08-01/02 were a weekend with zero rows. Worth correcting on the ticket.

**Why this is a revert, not a retune:** upstream exposes no config-only way to drop the raw-request span while keeping content. `_maybe_log_raw_request()` early-returns on exactly two conditions — `not _capture_in_span()` (kills content, the bug) or `_gen_ai_semconv_latest_experimental` (renames everything to `gen_ai.*`, breaking DAL's normalizer and Phoenix's openinference rendering). Decoupling needs a fork patch exposing `raw_request_logging`. Until then bloat is contained by the ENG2-1476 sentinel and ENG2-1469 trim script — **expect span size to regrow after this deploys.**

## ENG2-1494 — the HTTP-only claim is false

`get_arize_phoenix_config()` resolves a bare `:4317` endpoint to the gRPC exporter itself:

```python
if collector_endpoint.startswith("grpc://") or (
    ":4317" in collector_endpoint and "/v1/traces" not in collector_endpoint
):
    protocol = "otlp_grpc"
```

So prod's `http://sf-phoenix.internal:4317` → `otlp_grpc`, exporting fine — consistent with `fly/phoenix.fly.toml:29-33` (4317 "auto-dual-stacks"; the real IPv6 defect was on 6006, fixed by `PHOENIX_HOST="::"`) and with spans actually landing.

**The myth's likely origin:** a `:4317` endpoint carrying a `/v1/traces` suffix, which the resolver classifies as HTTP and then POSTs at a gRPC listener. That genuinely fails. The port got blamed; the path was the problem. Rule now documented.

Of the three possibilities the ticket listed, this is **#1 — docs are stale**. Config was right; the comment was wrong. **ENG2-1487's volume numbers need no annotation on this account.**

## Changes

| File | Change |
| -- | -- |
| `fly/litellm_config_fly.yaml` | Remove `message_logging: false`; replace with a do-not-re-add block explaining the mechanism |
| `docker-compose.yml` | Correct the HTTP-only comment (the only surviving source for the claim) |
| `fly/litellm.fly.toml` | Note gRPC is deliberate + verified; warn against the `/v1/traces` mix |
| `docs/design/observability-backend-strategy.md` | **New.** Cited by ENG2-1494 and ENG2-1486 but never committed — now exists as the single source of truth |

## Open question, deliberately not closed

~34% of spans retained content every day, stable to 0.4% for 9 days. Unexplained.

There's a discrepancy worth resolving first: ENG2-1510's own table implies only **623** August LLM spans (1.5%) carry real content, while 13,812 (32.6%) have **no** `input.value` at all — and 32.6% is suspiciously close to 34%. The "survivors" may be spans that never had an input value (parent `litellm_proxy_request` SERVER spans, guardrail spans), counted as not-redacted because the marker is absent rather than because content survived. §3 of the doc carries the discriminating query.

## Verification status

Root causes are proven at source level, executably (`_resolve_capture_mode` and `get_arize_phoenix_config` were run against real config values, not just read).

**Not verified, and cannot be from here:** no dockerd, no flyctl, no DB in this VM. §4 of the doc carries the post-deploy checklist as unchecked boxes — burst reconciliation, redaction/median-length confirmation, `%null_session` recovery, and a `span_size_sentinel.py --days 1` run to quantify bloat regrowth.

**Deploying `sf-litellm` is Adam's gated step.** Nothing here takes effect until then.

Refs ENG2-1510, ENG2-1494. Cc ENG2-1461 (the change being reverted), ENG2-1487 (volume numbers stand).