### PR TITLE
feat(ENG2-1510): content-presence sentinel + tests

### DIFF
--- a/scripts/capture_health.py
+++ b/scripts/capture_health.py
@@ -45,7 +45,25 @@ REDACTION_MARKER = "redacted-by-litellm"
 
 # Only spans that carry an input field participate. See the docstring.
 _HAS_INPUT = "attributes -> 'input' ->> 'value' IS NOT NULL"
-_IS_REDACTED = f"attributes -> 'input' ->> 'value' LIKE '%%{REDACTION_MARKER}%%'"
+
+# EXACT match, deliberately not LIKE '%...%'.
+#
+# When litellm redacts, it replaces the ENTIRE value: every one of the 9,308
+# redacted spans in the 2026-08-03..12 outage had input.value exactly equal to
+# the 19-character marker, one distinct value, no variants.
+#
+# A substring predicate additionally matches any span whose content merely
+# *mentions* the marker -- which includes every trace of an engineer debugging
+# this very outage. That is not hypothetical: during the post-deploy
+# verification on 2026-08-12 the LIKE form reported 6.8% redaction and failed
+# the check, when the true rate was 0.00%. The five "redacted" spans were
+# 616-3613 chars of the operator's own session discussing the bug. A genuinely
+# redacted span is 19 chars.
+#
+# Getting this wrong is worse than a nuisance: it makes the check cry wolf
+# exactly when someone is investigating a capture problem, which is precisely
+# when they need to trust it.
+_IS_REDACTED = f"attributes -> 'input' ->> 'value' = '{REDACTION_MARKER}'"
 
 _SQL = f"""
     SELECT name,

--- a/scripts/capture_health.py
+++ b/scripts/capture_health.py
@@ -1,0 +1,174 @@
+"""ENG2-1510: content-presence sentinel for the litellm->Phoenix capture path.
+
+The companion to span_size_sentinel.py, pointed the other way.
+
+span_size_sentinel only alarms when spans get BIGGER. The 2026-08-03 outage
+made them smaller: `callback_settings.arize_phoenix.message_logging: false`
+replaced every request body with the literal "redacted-by-litellm" (19 chars).
+The size sentinel scored that as an improvement and stayed quiet, which is why
+a total content blackout ran for nine days with a sentinel already deployed.
+
+This checks the floor instead of the ceiling: are we still capturing content at
+all? It is deliberately the inverse assertion, not an extension of ENG2-1476 --
+the two must both be green for the pipeline to be healthy, and neither can
+detect the other's failure.
+
+IMPORTANT -- denominator. Only spans that actually carry an `input.value` field
+are counted. `Claude_Code_Final_Output_0` is an output span with no input field
+at all; including it makes a total blackout look like a 66% one, which is
+exactly the misreading that happened during the ENG2-1510 investigation.
+
+Usage:
+  uv run python scripts/capture_health.py                 # last 24 hours
+  uv run python scripts/capture_health.py --hours 1       # post-deploy check
+  uv run python scripts/capture_health.py --max-redacted-pct 5 --min-median-chars 100
+
+DSN comes from $PHOENIX_SQL_DATABASE_URL (fallback: ../.env). Read-only.
+Exit codes: 0 = healthy, 1 = capture breach, 2 = no spans in window (inconclusive).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+import psycopg
+
+log = logging.getLogger("capture_health")
+
+REDACTION_MARKER = "redacted-by-litellm"
+
+# Only spans that carry an input field participate. See the docstring.
+_HAS_INPUT = "attributes -> 'input' ->> 'value' IS NOT NULL"
+_IS_REDACTED = f"attributes -> 'input' ->> 'value' LIKE '%%{REDACTION_MARKER}%%'"
+
+_SQL = f"""
+    SELECT name,
+           count(*)                                              AS with_input,
+           count(*) FILTER (WHERE {_IS_REDACTED})                AS redacted,
+           percentile_disc(0.5) WITHIN GROUP (
+               ORDER BY length(attributes -> 'input' ->> 'value')
+           )                                                     AS median_chars
+    FROM phoenix.spans
+    WHERE start_time > now() - (%(window)s)::interval
+      AND {_HAS_INPUT}
+    GROUP BY name
+    ORDER BY count(*) DESC
+"""
+
+
+def dsn_from_env() -> str:
+    dsn = os.environ.get("PHOENIX_SQL_DATABASE_URL")
+    if dsn:
+        return dsn
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    m = re.search(
+        r'^\s*PHOENIX_SQL_DATABASE_URL=("?)(.+?)\1\s*$', env_path.read_text(), re.M
+    )
+    if not m:
+        raise SystemExit("PHOENIX_SQL_DATABASE_URL not in env or ../.env")
+    return m.group(2)
+
+
+def evaluate(
+    rows: list[tuple[str, int, int, int | None]],
+    *,
+    max_redacted_pct: float,
+    min_median_chars: int,
+) -> tuple[int, list[str]]:
+    """Pure verdict logic so it can be unit-tested without a database.
+
+    Returns (exit_code, messages).
+    """
+    msgs: list[str] = []
+    if not rows:
+        return 2, ["no spans with an input field in the window - inconclusive"]
+
+    total = sum(r[1] for r in rows)
+    redacted = sum(r[2] for r in rows)
+    pct = 100.0 * redacted / total if total else 0.0
+    # Weighted-ish: report the worst median across span types, which is the one
+    # that would be hiding a partial regression.
+    medians = [r[3] for r in rows if r[3] is not None]
+    worst_median = min(medians) if medians else 0
+
+    for name, with_input, red, med in rows:
+        share = 100.0 * red / with_input if with_input else 0.0
+        msgs.append(
+            f"  {name[:38]:<40} input-bearing={with_input:<7} "
+            f"redacted={share:5.1f}%  median={med if med is not None else '-'}"
+        )
+
+    breach = False
+    if pct > max_redacted_pct:
+        breach = True
+        msgs.append(
+            f"BREACH: {pct:.1f}% of input-bearing spans are redacted "
+            f"(threshold {max_redacted_pct:.1f}%) - content capture is degraded"
+        )
+    if worst_median < min_median_chars:
+        breach = True
+        msgs.append(
+            f"BREACH: worst median input length is {worst_median} chars "
+            f"(threshold {min_median_chars}) - inputs are being truncated or replaced"
+        )
+    if not breach:
+        msgs.append(
+            f"healthy: {pct:.1f}% redacted, worst median {worst_median} chars, "
+            f"{total} input-bearing spans"
+        )
+    return (1 if breach else 0), msgs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--hours", type=float, default=24.0, help="lookback window in hours")
+    ap.add_argument(
+        "--max-redacted-pct",
+        type=float,
+        default=5.0,
+        help="fail if more than this %% of input-bearing spans are redacted",
+    )
+    ap.add_argument(
+        "--min-median-chars",
+        type=int,
+        default=100,
+        help="fail if the worst per-span-name median input length falls below this",
+    )
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+
+    t0 = time.perf_counter()
+    log.info(
+        "[capture] start window=%.1fh thresholds redacted<=%.1f%% median>=%d",
+        args.hours, args.max_redacted_pct, args.min_median_chars,
+    )
+
+    with psycopg.connect(dsn_from_env()) as conn, conn.cursor() as cur:
+        cur.execute("SET statement_timeout = '120s'")
+        cur.execute(_SQL, {"window": f"{args.hours} hours"})
+        rows = cur.fetchall()
+    log.info("[capture] query done in %.1fms", (time.perf_counter() - t0) * 1000)
+
+    code, msgs = evaluate(
+        rows,
+        max_redacted_pct=args.max_redacted_pct,
+        min_median_chars=args.min_median_chars,
+    )
+    for m in msgs:
+        (log.error if m.startswith("BREACH") else log.info)("[capture] %s", m)
+    log.info("[capture] verdict exit=%d in %.1fms", code, (time.perf_counter() - t0) * 1000)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/span_size_sentinel.py
+++ b/scripts/span_size_sentinel.py
@@ -46,6 +46,38 @@ def dsn_from_env() -> str:
     return m.group(2)
 
 
+def evaluate(
+    n: int | None,
+    avg_b: float | None,
+    p95_b: float | None,
+    max_b: float | None,
+    *,
+    avg_kb_threshold: float,
+    p95_kb_threshold: float,
+) -> tuple[int, list[str]]:
+    """Pure verdict so it can be unit-tested without a database.
+
+    Returns (exit_code, messages). 0 healthy, 1 size breach, 2 inconclusive.
+
+    NOTE (ENG2-1510): this check is DIRECTIONAL — it only fires when spans get
+    bigger. It cannot detect content loss, because losing content makes spans
+    smaller. See test_span_size_sentinel.py::test_cannot_detect_content_loss;
+    scripts/capture_health.py is the inverse check and both must be green.
+    """
+    if not n:
+        return 2, ["no spans in window - inconclusive"]
+    avg_kb, p95_kb, max_kb = (avg_b or 0) / 1024, (p95_b or 0) / 1024, (max_b or 0) / 1024
+    msgs = [f"{n} spans: avg={avg_kb:.1f}KB p95={p95_kb:.1f}KB max={max_kb:.1f}KB"]
+    if avg_kb > avg_kb_threshold or p95_kb > p95_kb_threshold:
+        msgs.append(
+            "SIZE BREACH - span bloat is back (3rd-regression guard, see "
+            "ENG2-1476/1461/1036). Check the sf-litellm image for a lost patch."
+        )
+        return 1, msgs
+    msgs.append("healthy")
+    return 0, msgs
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--days", type=float, default=7.0, help="lookback window in days")
@@ -85,19 +117,16 @@ def main() -> int:
         n, avg_b, p95_b, max_b = cur.fetchone()
         elapsed = time.perf_counter() - t0
 
-        if not n:
-            log.warning("[sentinel] no %s spans in window — inconclusive (%.1fs)",
-                        args.span_name, elapsed)
+        code, msgs = evaluate(
+            n, avg_b, p95_b, max_b,
+            avg_kb_threshold=args.avg_kb, p95_kb_threshold=args.p95_kb,
+        )
+        for m in msgs:
+            (log.error if "BREACH" in m else log.info)("[sentinel] %s (%.1fs)", m, elapsed)
+        if code == 2:
             return 2
 
-        avg_kb, p95_kb, max_kb = avg_b / 1024, p95_b / 1024, max_b / 1024
-        log.info(
-            "[sentinel] %d spans: avg=%.1fKB p95=%.1fKB max=%.1fKB in %.1fs",
-            n, avg_kb, p95_kb, max_kb, elapsed,
-        )
-
-        breach = avg_kb > args.avg_kb or p95_kb > args.p95_kb
-        if breach:
+        if code == 1:
             # Diagnose: fattest recent spans + which attribute key carries the bytes.
             cur.execute(
                 """
@@ -122,13 +151,8 @@ def main() -> int:
                     "[sentinel] BREACH sample: span id=%s total=%.1fKB fattest_key=%r (%.1fKB)",
                     span_id, total / 1024, key, key_bytes / 1024,
                 )
-            log.error(
-                "[sentinel] SIZE BREACH — span bloat is back (3rd-regression guard, "
-                "see ENG2-1476/1461/1036). Check the sf-litellm image for a lost patch."
-            )
             return 1
 
-        log.info("[sentinel] healthy")
         return 0
 
 

--- a/tests/test_capture_health.py
+++ b/tests/test_capture_health.py
@@ -22,7 +22,7 @@ from pathlib import Path
 # Add scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from capture_health import _HAS_INPUT, _SQL, evaluate  # noqa: E402
+from capture_health import _HAS_INPUT, _IS_REDACTED, _SQL, evaluate  # noqa: E402
 
 THRESHOLDS = {"max_redacted_pct": 5.0, "min_median_chars": 100}
 
@@ -102,3 +102,25 @@ def test_partial_regression_on_one_span_type_is_caught_by_median():
     code, msgs = evaluate(rows, **THRESHOLDS)
     assert code == 1, msgs
     assert any("median input length" in m for m in msgs)
+
+
+def test_redaction_predicate_is_exact_not_substring():
+    """Lesson #3, found during live post-deploy verification on 2026-08-12.
+
+    litellm replaces the WHOLE value when it redacts -- all 9,308 redacted spans
+    in the outage had input.value exactly equal to the 19-char marker, one
+    distinct value.
+
+    A `LIKE '%marker%'` predicate also matches any span whose content merely
+    MENTIONS the marker, which includes every trace of an engineer debugging
+    this outage. In the live check that inflated a true 0.00% to 6.8% and
+    failed the run -- the "redacted" spans were 616-3613 chars of an operator's
+    own session discussing the bug.
+
+    Crying wolf while someone investigates a capture problem is the one time
+    this check must be trustworthy, so the predicate stays exact.
+    """
+    assert "LIKE" not in _IS_REDACTED.upper(), (
+        "substring matching re-introduces the 2026-08-12 false positive"
+    )
+    assert "= 'redacted-by-litellm'" in _IS_REDACTED

--- a/tests/test_capture_health.py
+++ b/tests/test_capture_health.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for scripts/capture_health.py (ENG2-1510).
+
+The verdict logic is pure, so it is tested without a database. The cases that
+matter are not "does it add up" -- they encode the two specific ways this check
+could be built wrong, both of which happened for real during the ENG2-1510
+investigation:
+
+1. A denominator that includes spans with no input field turns a TOTAL blackout
+   into an apparent partial one (98.6% -> 66%), which is what made the outage
+   look like it had a surviving-content population and delayed the diagnosis.
+2. A threshold that only alarms on growth cannot see this failure at all --
+   that is span_size_sentinel.py, which scored the outage as an improvement and
+   stayed silent for nine days.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from capture_health import _HAS_INPUT, _SQL, evaluate  # noqa: E402
+
+THRESHOLDS = {"max_redacted_pct": 5.0, "min_median_chars": 100}
+
+# Real numbers pulled from phoenix.spans on 2026-08-12, mid-outage. Kept literal
+# so this test fails if the check ever stops recognising the outage it exists for.
+OUTAGE_ROWS = [
+    ("litellm_request", 2475, 2408, 19),
+    ("Claude_Code_Internal_Prompt_0", 2409, 2409, 19),
+]
+
+HEALTHY_ROWS = [
+    ("litellm_request", 2475, 3, 581),
+    ("Claude_Code_Internal_Prompt_0", 2409, 0, 505),
+]
+
+
+def test_healthy_capture_passes():
+    code, msgs = evaluate(HEALTHY_ROWS, **THRESHOLDS)
+    assert code == 0, msgs
+    assert any("healthy" in m for m in msgs)
+
+
+def test_the_real_outage_is_caught():
+    """The regression case. These are the actual 2026-08-03..12 numbers."""
+    code, msgs = evaluate(OUTAGE_ROWS, **THRESHOLDS)
+    assert code == 1
+    joined = "\n".join(msgs)
+    assert "BREACH" in joined
+    # Both signals should fire: the rate AND the collapsed median.
+    assert "redacted" in joined
+    assert "median input length" in joined
+
+
+def test_empty_window_is_inconclusive_not_healthy():
+    """No spans must never read as 'healthy' -- a dead pipeline is not a pass."""
+    code, msgs = evaluate([], **THRESHOLDS)
+    assert code == 2
+    assert "inconclusive" in msgs[0]
+
+
+def test_sql_counts_only_input_bearing_spans():
+    """Structural guard for lesson #1 in the module docstring.
+
+    Claude_Code_Final_Output_0 is an output span with no input.value field. It
+    can never carry the redaction marker, so counting it scores it as "not
+    redacted" and dilutes the rate. If this filter is ever dropped, a total
+    blackout will report as roughly two-thirds and look partial.
+    """
+    assert _HAS_INPUT in _SQL
+
+
+def test_including_a_no_input_span_type_would_mask_the_breach():
+    """Demonstrates the stakes of the filter above, at the verdict level.
+
+    Same outage, but with the output span type folded into the denominator as
+    'not redacted'. The rate drops below a naively-chosen threshold and the
+    check would go green during a total content blackout.
+    """
+    diluted = [*OUTAGE_ROWS, ("Claude_Code_Final_Output_0", 2409, 0, 4096)]
+    code, _ = evaluate(diluted, max_redacted_pct=70.0, min_median_chars=1)
+    assert code == 0, "precondition: dilution hides the breach at a loose threshold"
+
+    code, _ = evaluate(OUTAGE_ROWS, max_redacted_pct=70.0, min_median_chars=1)
+    assert code == 1, "undiluted, the same thresholds still catch it"
+
+
+def test_partial_regression_on_one_span_type_is_caught_by_median():
+    """A regression that hits only one span type keeps the overall rate low.
+
+    The worst-median rule is what catches it -- an aggregate-only check would
+    pass this.
+    """
+    rows = [
+        ("litellm_request", 5000, 0, 581),
+        ("Claude_Code_Internal_Prompt_0", 200, 200, 19),
+    ]
+    code, msgs = evaluate(rows, **THRESHOLDS)
+    assert code == 1, msgs
+    assert any("median input length" in m for m in msgs)

--- a/tests/test_span_size_sentinel.py
+++ b/tests/test_span_size_sentinel.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Tests for scripts/span_size_sentinel.py (ENG2-1476).
+
+This sentinel shipped 2026-08-04 with NO tests, and the ENG2-1510 postmortem
+found that gap mattered: the check was deployed and green throughout a nine-day
+total content blackout, because the outage made spans SMALLER and this check
+only fires when they get bigger.
+
+So the load-bearing test here is not "does the arithmetic work" — it is
+test_cannot_detect_content_loss, which pins that blind spot in place as a
+documented, asserted property. Anyone who later assumes this check covers
+capture health has a failing test to read.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from span_size_sentinel import evaluate  # noqa: E402
+
+KB = 1024
+THRESHOLDS = {"avg_kb_threshold": 10.0, "p95_kb_threshold": 50.0}
+
+
+def test_healthy_sizes_pass():
+    code, msgs = evaluate(500, 2 * KB, 4 * KB, 8 * KB, **THRESHOLDS)
+    assert code == 0
+    assert "healthy" in msgs[-1]
+
+
+def test_avg_breach_fails():
+    code, msgs = evaluate(500, 20 * KB, 30 * KB, 40 * KB, **THRESHOLDS)
+    assert code == 1
+    assert any("SIZE BREACH" in m for m in msgs)
+
+
+def test_p95_breach_fails_even_when_avg_is_fine():
+    """The bloat pattern is a few whales, not a uniform shift — avg alone hides it."""
+    code, msgs = evaluate(500, 3 * KB, 80 * KB, 900 * KB, **THRESHOLDS)
+    assert code == 1
+    assert any("SIZE BREACH" in m for m in msgs)
+
+
+def test_empty_window_is_inconclusive_not_healthy():
+    """A dead pipeline emits no spans. That must not read as a pass."""
+    code, msgs = evaluate(0, None, None, None, **THRESHOLDS)
+    assert code == 2
+    assert "inconclusive" in msgs[0]
+
+
+def test_cannot_detect_content_loss():
+    """THE POINT OF THIS FILE. Pins the blind spot found by ENG2-1510.
+
+    During the 2026-08-03..12 outage every request body was replaced by a
+    19-character marker. Spans went from ~70KB to under 1KB and this sentinel
+    reported healthy for nine consecutive days, because shrinking is what it is
+    built to approve of.
+
+    This asserts that behaviour deliberately rather than pretending otherwise:
+    the check is directional by design, and scripts/capture_health.py is the
+    inverse. Both must be green. If someone ever makes this check fail on tiny
+    spans, they will break this test and should read the docstring before
+    "fixing" it — a small span is normal, an EMPTY one is not, and telling those
+    apart needs content inspection, which lives in the other script.
+    """
+    # Real shape of the outage: ~900-byte spans carrying only a redaction marker.
+    code, msgs = evaluate(2475, 900, 1100, 1300, **THRESHOLDS)
+    assert code == 0, "size sentinel is expected to pass here — that is the blind spot"
+    assert "healthy" in msgs[-1]


### PR DESCRIPTION
Companion to `span_size_sentinel.py`, pointed the other way.

## Why

`span_size_sentinel.py` only alarms when spans get **bigger**. The 2026-08-03 outage made them **smaller** — `message_logging: false` replaced every request body with `redacted-by-litellm` (19 chars). The existing sentinel scored a total content blackout as an improvement and stayed silent for **nine days**, with a sentinel already deployed.

This checks the floor instead of the ceiling. The two are deliberately inverse — neither can detect the other's failure, so both must be green.

Covers ENG2-1510's existing "add a monitor or check so a future redaction regression surfaces" acceptance criterion. No new ticket.

## Verified against live data before the fix deploys

It correctly **fails right now**:

```
litellm_request                input-bearing=2475  redacted= 97.3%  median=19
Claude_Code_Internal_Prompt_0  input-bearing=2409  redacted=100.0%  median=19
BREACH: 98.6% of input-bearing spans are redacted (threshold 5.0%)
BREACH: worst median input length is 19 chars (threshold 100)
verdict exit=1
```

After `sf-litellm` is deployed this should flip to exit 0. That makes it the post-deploy verification step as well as the regression guard.

## The denominator is the whole game

Only spans that **carry an input field** are counted. `Claude_Code_Final_Output_0` is an output span with no `input.value` at all — counting it scores it as "not redacted" and turns a 98.6% blackout into an apparent 66% one. That is the exact misreading that made this outage look partial and delayed the diagnosis. Guarded structurally by a test.

## Tests (6, all pure — no DB)

- healthy data passes
- **the real outage numbers are kept literal**, so the check cannot stop recognising the bug it exists for
- an empty window is `inconclusive` (exit 2), never `healthy` — a dead pipeline is not a pass
- the input-bearing filter is asserted structurally
- dilution is demonstrated to mask the breach
- a single-span-type regression is caught by the worst-median rule, where an aggregate-only check passes

## Usage

```bash
uv run python scripts/capture_health.py            # last 24h
uv run python scripts/capture_health.py --hours 1  # post-deploy check
```

Note: `span_size_sentinel.py` still has no tests.