### PR TITLE
docs(ENG2-1509): tool-span + autonomy recipes, correct Recipe 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ sync, no export:
 ```sql
 INSTALL postgres; LOAD postgres;
 ATTACH getenv('PHOENIX_SQL_DATABASE_URL') AS pg (TYPE postgres, READ_ONLY);
--- push aggregates down with postgres_query(); a plain scan of 1.2M spans times out
+-- push aggregates down with postgres_query() so Postgres does the work
 SELECT * FROM postgres_query('pg', $$
-  SELECT ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' AS who,
+  SELECT CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END AS who,
          count(*) AS spans FROM phoenix.spans
   WHERE start_time > now() - INTERVAL '14 days' GROUP BY 1 ORDER BY 2 DESC
 $$);

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -10,7 +10,7 @@ This document describes the unified schema used by `dev_agent_lens` to normalize
 | `trace_id` | `str` | Identifier for the trace this span belongs to |
 | `parent_id` | `str \| None` | ID of the parent span (None for root spans) |
 | `name` | `str` | Name/label of the span |
-| `span_kind` | `str \| None` | Type of span (LLM, TOOL, CHAIN, etc.) |
+| `span_kind` | `str \| None` | Type of span (LLM, TOOL, CHAIN, etc.). **In the shared corpus this is effectively `LLM` or `UNKNOWN` only** — do not filter `span_kind='TOOL'` to find tool activity; see [query-cookbook.md Recipe 8](docs/query-cookbook.md#8-what-tools-did-the-agent-actually-run) |
 | `start_time` | `str` | ISO-8601 timestamp when span started |
 | `end_time` | `str \| None` | ISO-8601 timestamp when span ended |
 | `status_code` | `str \| None` | Status of the span (OK, ERROR, etc.) |

--- a/dev_agent_lens/core/identity.example.yaml
+++ b/dev_agent_lens/core/identity.example.yaml
@@ -31,6 +31,8 @@ people:
         evidence: os_user=personb (N spans, Nd)
         note: Second account, same human — inferred, not yet self-reported.
 
-# Accounts seen in the data that map to no person (e.g. sandbox VMs, which carry
-# no account_uuid). Keep them here so `is_complete` reflects reality.
+# Accounts seen in the data that map to no person. Keep them here so `is_complete`
+# reflects reality. NOTE: an absent account_uuid does NOT mean "a sandbox VM" — that
+# is backwards. Sandbox spans are 93.6% attributed; 98.5% of unattributed spans are
+# laptop traffic (measured 2026-08-12, ENG2-1509).
 unclaimed: []

--- a/dev_agent_lens/core/identity.py
+++ b/dev_agent_lens/core/identity.py
@@ -79,7 +79,7 @@ class IdentityMap:
         if person:
             return person.email
         if not account_uuid:
-            return "(sandbox/unattributed)"
+            return "(unattributed)"
         return f"(unclaimed:{account_uuid[:8]})"
 
     @property

--- a/docs/design/dal-db-learnings-oltp-olap.md
+++ b/docs/design/dal-db-learnings-oltp-olap.md
@@ -19,7 +19,7 @@ when that stops being true.
 | Store | What | Scale (2026-08-04) |
 |---|---|---|
 | `phoenix.spans` (shared Supabase) | LLM traces: litellm → Phoenix callback, one `litellm_request` span per model call, JSONB `attributes` | 81k spans, **584 MB** incl. 150 MB trgm index (was 31 GB on 07-28) |
-| `workspace_*.sandbox_agent_events` / `_sessions` | ACP rollout capture: what the sandboxed agent *did* (tool calls, status, prompts), joinable to spans by `session_id` | 13.6k events, 115 sessions, 16 schemas |
+| `workspace_*.sandbox_agent_events` / `_sessions` | ACP rollout capture: what the sandboxed agent *did* (tool calls, status, prompts), joinable to spans by `session_id` | 13.6k events, 115 sessions, 17 schemas (11 populated, 2026-08-12) |
 | Local session JSONLs (`~/.claude/projects/`) | Claude Code's own transcripts — richest per-session record, but pruned ~30 days and per-machine | 132 sessions (Jul 7 →) |
 | Parquet archive (`~/dal-archive/phoenix-2026-08-03` + S3) | Full pre-cleanup span history, twice-verified (exact id-set equality) | 27 GB, 1.31M spans, May 6 → Aug 3 |
 | `dal_catalog.sessions` (new, ENG2-1470) | Precomputed per-session lookup: person, category, summary, ticket mentions | 1,333 sessions, 19 categories |
@@ -138,7 +138,8 @@ ENG2-1462's build-vs-buy question with real evidence.
    construction.
 
 **Open questions:**
-- Rollout identity: 550 non-noise sessions have no account tag (sandbox VMs mint no
+- Rollout identity: 550 non-noise sessions have no account tag (NOT because they are
+  sandbox VMs — sandbox spans are 93.6% attributed; see ENG2-1509) (sandbox VMs mint no
   identity). Worth threading `account_uuid` through the rollout env so evals attribute?
 - Archive cadence: parquet sync is manual today; post-08-03 spans exist only in hot PG.
   Monthly cron?

--- a/docs/markdown_export_pipeline_documentation.md
+++ b/docs/markdown_export_pipeline_documentation.md
@@ -61,7 +61,11 @@ class PhoenixClient:
 - `context.trace_id` - Trace group identifier
 - `parent_id` - Parent span reference
 - `name` - Span name (e.g., "Claude_Code_Tool_Read")
-- `span_kind` - Type: LLM, TOOL, CHAIN, etc.
+- `span_kind` - Type: LLM, TOOL, CHAIN, etc. **In our corpus this is effectively
+  `LLM` or `UNKNOWN` only** — measured 2026-08-12: LLM 110,018 · UNKNOWN 18,249 · TOOL 1,080
+  (all TOOL rows dated 2026-08-12, i.e. brand new). **Do not filter on `span_kind='TOOL'`
+  to find tool activity** — the tool record lives in `<workspace_*>.sandbox_agent_events`.
+  See [query-cookbook.md Recipe 8](query-cookbook.md#8-what-tools-did-the-agent-actually-run).
 - `attributes` - Nested JSON with all metadata
 - `start_time`, `end_time` - Timestamps
 
@@ -389,7 +393,7 @@ class UnifiedSpan(TypedDict, total=False):
     trace_id: str
     parent_id: str | None
     name: str
-    span_kind: str | None        # LLM, TOOL, CHAIN
+    span_kind: str | None        # in practice: LLM or UNKNOWN (see §1.1 — not a tool index)
     start_time: str              # ISO-8601
     end_time: str | None         # ISO-8601
     status_code: str | None

--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -36,7 +36,16 @@ bare-```sql``` recipes (#5–#9) run by wrapping the SQL: `con.execute("""<sql>"
 `<workspace_*>.sandbox_agent_events` is what the *agent* did — tool calls, statuses,
 prompts — across 17 per-workspace schemas. Recipes 1–7 are span recipes; **if your question
 is about tools or agent actions, start at [Recipe 8](#8-what-tools-did-the-agent-actually-run),
-not here.** The two join on `session_id`. See [querying.md](querying.md#the-two-surfaces).
+not here.** See [querying.md](querying.md#the-two-surfaces).
+
+**To join the two surfaces:** `session_id` is **not** at `attributes->'metadata'->>'session_id'` — that path returns **0 rows**. It is nested inside the same field the account id lives in:
+
+```sql
+CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%'
+     THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'session_id' END
+```
+
+That resolves on 67,128 spans; 102 of the 117 `sandbox_agent_events` sessions (87%) match.
 
 Two conventions used throughout:
 
@@ -80,13 +89,17 @@ Two conventions used throughout:
 > | Gap | Window | Filter |
 > |---|---|---|
 > | **litellm redaction** (ENG2-1510) | 2026-08-03 → 2026-08-12 | `attributes::text NOT LIKE '%redacted-by-litellm%'` |
-> | **`dal_trim` dedupe** (ENG2-1469) | historical fat spans, trimmed 2026-08-06 | `... NOT LIKE '%dal_trim%'` |
+> | **`dal_trim` dedupe** (ENG2-1469) | historical fat spans, trimmed 2026-08-06 | `attributes->'input'->>'value' NOT LIKE '%dal_trim%'` |
 >
-> Redaction hit **96–98% of `litellm_request` spans** on 08-04 → 08-11. It was fixed on
+> Redaction hit **90–98% of `litellm_request` spans** on 08-04 → 08-11 (most days 96–98%; 08-09 was 90.2% on a low-volume day). It was fixed on
 > 2026-08-12 by commit `59c7e14` — same-day spans were 47% redacted as the fix rolled out,
 > and capture after that is healthy. So this is a **bounded historical hole, not an ongoing
 > outage**: `start_time < '2026-08-03'` is clean, and so is anything after 08-12. The
 > `dal_trim` rows point at `llm.input_messages` or the parquet archive for their content.
+>
+> **Apply the `dal_trim` filter to `attributes->'input'->>'value'`, not `attributes::text`** —
+> the marker also appears elsewhere in the blob, so the broad form excludes **47,926** spans
+> (37% of the corpus) where the narrow one excludes **14,164** (11%). Recipes here use narrow.
 >
 > `sandbox_agent_events` is unaffected by both — it's a separate capture path. That's the
 > fallback for any question about the August window ([Recipe 8](#8-what-tools-did-the-agent-actually-run)).
@@ -176,8 +189,9 @@ spans = con.execute("""
            coalesce(llm_token_count_prompt,0)+coalesce(llm_token_count_completion,0) AS tokens
     FROM phoenix.spans
     WHERE start_time > now() - INTERVAL '30 days'
+      -- '<account-uuid>': a person's uuid, from identity.yaml
       AND CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END
-          = '<account-uuid>'   -- a person's uuid, from identity.yaml
+          = '<account-uuid>'
   $q$)
 """).df()
 
@@ -201,11 +215,21 @@ turn is the agent talking to itself — `extract_human_turns()` drops it.
 | Corpus | Candidate user turns | Genuine human turns | Drop rate |
 |---|---|---|---|
 | `phoenix.spans` text turns (this recipe, pre-08-01, content-bearing) | 9,261 | 5,473 | **40.9%** |
-| Local session JSONLs (`~/.claude/projects/`, 65-day window) | 14,209 | 3,928 | **72%** |
+| `phoenix.spans`, scoped to `sf-workspaces` (what [Recipe 9](#9-whats-our-autonomy-ratio-inferring-the-stop-signal-without-stop_reason) uses) | 6,511 | 4,538 | **30.3%** |
+| Local JSONLs — **all** `type:"user"` events (396 files) | 38,343 | 3,994 | **89.6%** |
+| Local JSONLs — only events carrying a text block | 5,616 | 3,994 | **28.9%** |
 
-Both measured 2026-08-12. The local JSONLs drop far more because they also carry
-machine-injected "user" events — tool results, system reminders, hook output — that never
-reach the model as a text turn. **Budget sample sizes off the row that matches your source.**
+All measured 2026-08-12. **The definition of "candidate" matters more than the corpus does** —
+the two local-JSONL rows share a numerator and differ 3× in rate purely on what counts as a
+candidate. Most `type:"user"` events are machine-injected (tool results, system reminders,
+hook output) and carry no text block at all, so counting them inflates the denominator ~7×.
+**Budget off the row matching your source *and* your candidate definition, and say which.**
+
+> An earlier draft cited **72%** (14,209 → 3,928) for the local JSONLs, taken from ENG2-1509.
+> It does not reproduce: sweeping all 396 files under every reasonable candidate definition
+> brackets it (28.9% … 89.6%) but never lands on it, and no subset reaches 14,209 candidates.
+> The numerator was close (3,928 vs 3,994); the denominator was not. The rows above are a
+> re-measurement, not the ticket's figure.
 
 ```python
 from dev_agent_lens.core.prompts import extract_human_turns
@@ -255,8 +279,13 @@ rows["week"] = ...   # bucket by the span's start_time week, then classify + rat
 ## 5. Where did they get stuck? (blockers — user story 2)
 
 > **Content-based recipe** — the `context` column below reads `attributes->'input'->>'value'`,
-> so redacted and `dal_trim` rows return blank context next to a real `status_message`. Add
-> the exclusions from Recipe 3, or the friction in the 08-03 → 08-12 window looks contextless.
+> so redacted and `dal_trim` rows return blank context. Add the exclusions from Recipe 3, or
+> the friction in the 08-03 → 08-12 window looks contextless.
+>
+> **`status_message` is empty for every span in this corpus** (verified 2026-08-12: 0 non-empty
+> of ~130k, across all of OK/UNSET/ERROR) — so select `status_code`, not `status_message`, or
+> you get a column that is silently always `''`. The signal is in `context`: of ~1,524 ERROR
+> rows in a 30-day window, ~1,028 are the string `quota` and the rest are real turns.
 
 Errors and their surrounding context are the cheap version of "find the friction":
 
@@ -264,11 +293,12 @@ Errors and their surrounding context are the cheap version of "find the friction
 SELECT * FROM postgres_query('pg', $$
   SELECT start_time::date AS day,
          left(attributes->'input'->>'value', 120) AS context,
-         status_message
+         status_code
   FROM phoenix.spans
   WHERE start_time > now() - INTERVAL '30 days'
+    -- '<account-uuid>': a person's uuid, from identity.yaml
     AND CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END
-        = '<account-uuid>'   -- a person's uuid, from identity.yaml
+        = '<account-uuid>'
     AND status_code = 'ERROR'
   ORDER BY start_time DESC LIMIT 50
 $$);
@@ -380,7 +410,8 @@ $$);
 Answering the ticket's motivating question — *what tools ran in the UUH replay eval?* —
 that returns `Bash 26, Write 2, Monitor 1`: **29 tool calls**. If you have seen "212 tool
 events" quoted for this eval, that is `count(*) WHERE tool_call_id IS NOT NULL` — 212 of the
-schema's 586 rows carry a tool id (the 29 calls, 180 status updates, and 3 others). It counts
+schema's 586 rows carry a tool id (the 29 calls, 180 status updates, and 3 `assistant` rows
+tagged `tool_name='Agent'`). It counts
 *rows about tools*, not tools run. **29 is the number of tools that ran.**
 
 Fleet-wide, top tools across all 11 populated schemas: `Bash 735 · Read 237 · Edit 85 ·
@@ -415,8 +446,8 @@ $$);
 > a small but *consistent* sample.
 
 **Do NOT grep `tool_calls`** — that's OpenAI's vocabulary (the estate is Anthropic-native:
-`/v1/messages` ≫ `/v1/chat/completions`). It matches ~0.25% of this corpus and reads as
-confirmation the data is missing.
+`/v1/messages` ≫ `/v1/chat/completions`). Measured, it matches **0.30%** of `input.value` —
+small enough to read as confirmation the data is missing.
 
 > **This advice is dated 2026-08-12 and will age.** Post-ENG2-1510, Phoenix *is* starting to
 > emit properly-named tool spans (`Claude_Code_Tool_Bash`, `Claude_Code_Tool_Read`, …) under
@@ -476,16 +507,21 @@ $$);
 **Correct the denominator.** The text bucket is not all human — it includes the agent
 talking to itself. The query above returns *counts*, so to apply the correction you re-run it
 selecting the text bucket's `v` instead of counting it, and pass that through
-`extract_human_turns()` exactly as Recipe 3 does. On the span corpus that drops **40.9%**, so
-the corrected ratio is the raw one **÷ 0.591** (≈1.7×).
+`extract_human_turns()` exactly as Recipe 3 does.
+
+**Use the divisor for the corpus you filtered to.** This recipe pins `sf-workspaces`, where
+the drop rate is **30.3%** → divide by **0.697**. The 40.9% figure in Recipe 3 is the
+*all-projects* rate and gives a divisor of 0.591 — applying it here would overstate every
+corrected ratio by ~18%. Same trap as the project filter itself: change the corpus, change
+the constant.
 
 **Measured baseline (`sf-workspaces`, 2026-08-12), so you have a reference to diff against:**
 
-| Month | agent-continued | text turns | raw ratio | corrected (÷0.591) |
+| Month | agent-continued | text turns | raw ratio | corrected (÷0.697) |
 |---|---|---|---|---|
-| 2026-05 | 240 | 39 | 6.15 : 1 | ~10.4 : 1 |
-| 2026-06 | 8,862 | 2,361 | 3.75 : 1 | ~6.4 : 1 |
-| 2026-07 | 9,902 | 3,127 | 3.17 : 1 | ~5.4 : 1 |
+| 2026-05 | 240 | 39 | 6.15 : 1 | ~8.8 : 1 |
+| 2026-06 | 8,862 | 2,361 | 3.75 : 1 | ~5.4 : 1 |
+| 2026-07 | 9,902 | 3,127 | 3.17 : 1 | ~4.5 : 1 |
 | 2026-08 | 540 | 328 | 1.65 : 1 | **unusable** — 97% redacted, tiny surviving sample |
 
 **Read the trend with care, and don't headline it.** On live-project traffic the ratio
@@ -512,7 +548,7 @@ Supabase enforces a `statement_timeout`, and `attributes` (JSONB) has no index.
 
 **This is much less of a problem than it used to be.** Post-debloat (see the corpus-size
 note at the top), full-corpus scans over all 129k spans — including `attributes::text LIKE`
-predicates — completed in **6–18s** when this page was verified on 2026-08-12. Reach for the
+predicates — completed in **6–35s** when this page was verified on 2026-08-12. Reach for the
 mitigations below only when you actually hit a timeout, not pre-emptively.
 
 If a query does die with `canceling statement due to statement timeout`:

--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -58,8 +58,10 @@ Two conventions used throughout:
 > accurate when written on 2026-07-15 and stopped being true on **2026-08-03**, when
 > `scripts/debloat_spans.py` (ENG2-1461) deliberately deleted ~1.24M duplicate rows —
 > `raw_gen_ai_request` and pre-May `Claude_Code%` L² children — after archiving them to
-> `~/dal-archive/phoenix-2026-08-03` + S3. Nothing was lost; the DB went 31 GB → 5.5 GB.
-> Scans are fast now. Don't size capacity or cost off the old number.
+> `~/dal-archive/phoenix-2026-08-03` + S3 (the script refuses to run without a verified
+> archive). Nothing was lost. Measured 2026-08-12 after reclaim: **whole DB 1,761 MB, of
+> which `phoenix.spans` is 1,345 MB** — down from ~31 GB pre-debloat. Scans are fast now.
+> Don't size capacity or cost off the old number.
 
 > **⚠ Two content gaps every content-based recipe must exclude.** Both leave the span row
 > in place with its metadata intact, so counts look healthy while the *text* is gone:

--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -63,6 +63,13 @@ Two conventions used throughout:
 > which `phoenix.spans` is 1,345 MB** — down from ~31 GB pre-debloat. Scans are fast now.
 > Don't size capacity or cost off the old number.
 
+> **Retention floor: 2026-05-06. There is nothing before it — on either surface.** The
+> earliest span is 2026-05-06 (a partial day, 94 rows); `sandbox_agent_events` doesn't start
+> until 2026-05-15; and the parquet archive itself only runs 2026-05-06 → 08-03. So the
+> **2026-04-01 → 2026-05-06 window is a hard capture gap with no data anywhere**, not a
+> query you haven't written yet. This bounds every longitudinal claim: any "since Q2" or
+> "over the last N months" analysis silently starts on 2026-05-06. Say so when you report one.
+
 > **⚠ Two content gaps every content-based recipe must exclude.** Both leave the span row
 > in place with its metadata intact, so counts look healthy while the *text* is gone:
 >

--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -30,7 +30,7 @@ con.execute(f"ATTACH '{os.environ['PHOENIX_SQL_DATABASE_URL']}' AS pg (TYPE post
 
 Keep that `con` — the recipes below run in the **same `uv run python` session**: recipes #1
 and #2 each rebuild `con` so they stand alone, but #3–#4 reuse the `con` above, and the
-bare-```sql``` recipes (#5–#7) run by wrapping the SQL: `con.execute("""<sql>""").df()`.
+bare-```sql``` recipes (#5–#9) run by wrapping the SQL: `con.execute("""<sql>""").df()`.
 
 **There are two surfaces, not one.** `phoenix.spans` is what the *model* saw and said.
 `<workspace_*>.sandbox_agent_events` is what the *agent* did — tool calls, statuses,
@@ -51,6 +51,10 @@ Two conventions used throughout:
   ```
 
   Shape breakdown: 67,016 castable JSON objects · 54,958 absent · 7,421 raw strings.
+  **All 7,421 raw-string rows fall on 2026-05-21 → 05-22**, so a query windowed to recent
+  data won't trip the error and the guard will look pointless — it isn't, it just only
+  fires on windows covering those two days. A `start_time > '2026-05-23'` floor is the
+  cheaper alternative when your question allows it.
 - **Push work down.** Anything that scans or groups goes inside `postgres_query('pg', $$ … $$)` so Postgres does it.
 
 > **Corpus size (measured 2026-08-12): 129,347 spans, 2026-05-06 → present.** An earlier
@@ -374,8 +378,10 @@ $$);
 ```
 
 Answering the ticket's motivating question — *what tools ran in the UUH replay eval?* —
-that returns `Bash 26, Write 2, Monitor 1`: **29 tool calls** (plus 180 `tool_call_update`
-rows, which is where a "212 tool events" figure comes from).
+that returns `Bash 26, Write 2, Monitor 1`: **29 tool calls**. If you have seen "212 tool
+events" quoted for this eval, that is `count(*) WHERE tool_call_id IS NOT NULL` — 212 of the
+schema's 586 rows carry a tool id (the 29 calls, 180 status updates, and 3 others). It counts
+*rows about tools*, not tools run. **29 is the number of tools that ran.**
 
 Fleet-wide, top tools across all 11 populated schemas: `Bash 735 · Read 237 · Edit 85 ·
 mcp__linear-server__get_issue 43 · Write 41`.
@@ -386,16 +392,39 @@ that path and the `tool_name` column agreed on 1,218 of 1,218 `tool_call` rows. 
 column; keep the JSON path as a fallback if you hit a row where the column is null.
 
 **Phoenix-side complement.** If you must find tool activity in spans, grep the *content*,
-not `span_kind`:
+not `span_kind` — and **carry the redaction filter**, or you will reproduce the exact wrong
+conclusion this recipe exists to prevent:
 
 ```sql
--- the estate is Anthropic-native: /v1/messages ≫ /v1/chat/completions
-attributes->'input'->>'value' LIKE '%tool_use%'      -- the model asked for a tool
-attributes->'input'->>'value' LIKE '%tool_result%'   -- a tool came back
+SELECT * FROM postgres_query('pg', $$
+  SELECT to_char(start_time,'YYYY-MM') AS mon,
+         count(*)                                                      AS spans,
+         count(*) FILTER (WHERE attributes->'input'->>'value' LIKE '%tool_use%')    AS asked_for_tool,
+         count(*) FILTER (WHERE attributes->'input'->>'value' LIKE '%tool_result%') AS tool_returned
+  FROM phoenix.spans
+  WHERE name = 'litellm_request'
+    AND attributes::text NOT LIKE '%redacted-by-litellm%'   -- ← omit this and August reads ~0
+  GROUP BY 1 ORDER BY 1
+$$);
 ```
 
-**Do NOT grep `tool_calls`** — that's OpenAI's vocabulary. It matches ~0.25% of this corpus
-and reads as confirmation the data is missing.
+> **Why the filter is not optional here.** Without it, the `tool_use` hit rate reads ~16% in
+> May, ~45% in June and July, and **3.5% in August** — a 13× cliff that looks exactly like
+> "we stopped capturing tool activity." It isn't; it's the redaction window. That inference
+> is the one that produced the "DAL has zero tool spans" claim. With the filter, August is
+> a small but *consistent* sample.
+
+**Do NOT grep `tool_calls`** — that's OpenAI's vocabulary (the estate is Anthropic-native:
+`/v1/messages` ≫ `/v1/chat/completions`). It matches ~0.25% of this corpus and reads as
+confirmation the data is missing.
+
+> **This advice is dated 2026-08-12 and will age.** Post-ENG2-1510, Phoenix *is* starting to
+> emit properly-named tool spans (`Claude_Code_Tool_Bash`, `Claude_Code_Tool_Read`, …) under
+> `span_kind='TOOL'`. Today there are too few, over too short a window, to be a usable index —
+> hence content-grepping. **Re-check before relying on this:** if
+> `SELECT min(start_time), max(start_time), count(*) FROM phoenix.spans WHERE span_kind='TOOL'`
+> now spans weeks rather than a single day, prefer querying those spans directly and treat
+> this section as historical.
 
 ---
 
@@ -404,7 +433,7 @@ and reads as confirmation the data is missing.
 The share of turns the agent takes *without* a human typing something is the centerpiece of
 the off-call-human-time program. It is computable today, from spans alone.
 
-**Don't reach for `stop_reason` — it's near-absent.** Only 703 of 129,355 spans carry it
+**Don't reach for `stop_reason` — it's near-absent.** Only 703 of ~129.3k spans carry it
 (0.54%); `sandbox_agent_events` is similar at ~1%. Any recipe gated on it silently returns
 almost nothing.
 
@@ -418,13 +447,23 @@ its shape tells you who initiated:
 
 The ratio of the two **is** the autonomy signal:
 
+> **Filter to one project or this number is wrong** — this is Recipe 7's warning, and it
+> bites hardest right here. `dev-agent-lens` died on 2026-06-06 but still holds 36,250
+> spans, and it was a *far* less autonomous workload. Left unfiltered it supplies **93% of
+> May's rows** and drags the May ratio from 6.15:1 down to 1.23:1 — which flips the headline
+> from "autonomy is declining" to "autonomy tripled." Join to `phoenix.projects` and pick
+> one.
+
 ```sql
 SELECT * FROM postgres_query('pg', $$
   WITH b AS (
-    SELECT to_char(start_time,'YYYY-MM') AS mon, attributes->'input'->>'value' AS v
-    FROM phoenix.spans
-    WHERE name = 'litellm_request'
-      AND attributes::text NOT LIKE '%redacted-by-litellm%'   -- see the content-gap note
+    SELECT to_char(s.start_time,'YYYY-MM') AS mon, s.attributes->'input'->>'value' AS v
+    FROM phoenix.spans s
+    JOIN phoenix.traces   t ON t.id = s.trace_rowid
+    JOIN phoenix.projects p ON p.id = t.project_rowid
+    WHERE s.name = 'litellm_request'
+      AND p.name = 'sf-workspaces'                             -- live project; NOT the dead dev-agent-lens
+      AND s.attributes::text NOT LIKE '%redacted-by-litellm%'  -- see the content-gap note
   )
   SELECT mon,
     count(*) FILTER (WHERE v NOT LIKE '%dal_trim%' AND v LIKE '%tool_result%') AS agent_continued,
@@ -435,17 +474,31 @@ $$);
 ```
 
 **Correct the denominator.** The text bucket is not all human — it includes the agent
-talking to itself. Pass it through `extract_human_turns()` (Recipe 3) before treating it as
-"human turns"; on the span corpus that drops ~41%, which raises the ratio by ~1.7×.
+talking to itself. The query above returns *counts*, so to apply the correction you re-run it
+selecting the text bucket's `v` instead of counting it, and pass that through
+`extract_human_turns()` exactly as Recipe 3 does. On the span corpus that drops **40.9%**, so
+the corrected ratio is the raw one **÷ 0.591** (≈1.7×).
 
-**Measured baseline (2026-08-12), so you have a reference to diff against:**
+**Measured baseline (`sf-workspaces`, 2026-08-12), so you have a reference to diff against:**
 
-| Month | agent-continued | text turns | raw ratio | corrected (÷0.59) |
+| Month | agent-continued | text turns | raw ratio | corrected (÷0.591) |
 |---|---|---|---|---|
-| 2026-05 | 3,530 | 2,862 | 1.23 : 1 | ~2.1 : 1 |
-| 2026-06 | 8,938 | 2,375 | 3.76 : 1 | ~6.4 : 1 |
+| 2026-05 | 240 | 39 | 6.15 : 1 | ~10.4 : 1 |
+| 2026-06 | 8,862 | 2,361 | 3.75 : 1 | ~6.4 : 1 |
 | 2026-07 | 9,902 | 3,127 | 3.17 : 1 | ~5.4 : 1 |
-| 2026-08 | 516 | 314 | 1.64 : 1 | **unusable** — 97% redacted, tiny surviving sample |
+| 2026-08 | 540 | 328 | 1.65 : 1 | **unusable** — 97% redacted, tiny surviving sample |
+
+**Read the trend with care, and don't headline it.** On live-project traffic the ratio
+*declines* May → July. But May is only 279 classifiable spans (the project had just started;
+the retention floor is 2026-05-06), against ~11k in June and ~13k in July — so the "6.15"
+is a thin, early-adopter sample, not a fleet baseline. June → July, where the volume is
+comparable, is the only month-over-month comparison here that carries weight: **3.75 → 3.17,
+a mild decline.** Anyone quoting a May-to-July trend is quoting sampling noise.
+
+> For contrast, the **unfiltered** numbers — which include the dead `dev-agent-lens`
+> project — are May 3,530/2,862 = 1.23:1, June 8,938/2,375 = 3.76:1. The May figure is 93%
+> dead-project traffic and inverts the trend. This is what the project filter is protecting
+> you from.
 
 **Cross-check against `sandbox_agent_events`**, which gives an exact per-tool count with no
 redaction exposure and no inference at all (Recipe 8). If the two disagree sharply for a

--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -174,6 +174,12 @@ for s in summarize(spans):          # ~46 real sessions, not 1 thread
 
 ## 3. What did they actually type? (human turns, no agent noise)
 
+> **Content-based recipe — exclude the two content gaps** (see [the note above](#query-cookbook)):
+> add `AND attributes::text NOT LIKE '%redacted-by-litellm%'` and
+> `AND attributes->'input'->>'value' NOT LIKE '%dal_trim%'`, or window to
+> `start_time < '2026-08-03'`. Without them, 96–98% of 08-04 → 08-11 rows are empty text and
+> your counts silently undercount.
+
 The prompt text is at the tail of the message array. A large share of what looks like a user
 turn is the agent talking to itself — `extract_human_turns()` drops it.
 
@@ -211,6 +217,10 @@ for turn in extract_human_turns(candidates):
 
 ## 4. Learning vs. building (user story 1)
 
+> **Content-based recipe** — it inherits Recipe 3's output, so it inherits Recipe 3's
+> redaction / `dal_trim` exclusions too. A learning-vs-building split computed over the
+> 2026-08-03 → 08-12 window is measuring the surviving 2–4% of turns, not the month.
+
 Recipes 2 + 3 give you the person's real sessions and real prompts. The learning-vs-building
 split is a *judgment* over those prompts — there's no column for it. Two ways:
 
@@ -230,6 +240,10 @@ rows["week"] = ...   # bucket by the span's start_time week, then classify + rat
 ```
 
 ## 5. Where did they get stuck? (blockers — user story 2)
+
+> **Content-based recipe** — the `context` column below reads `attributes->'input'->>'value'`,
+> so redacted and `dal_trim` rows return blank context next to a real `status_message`. Add
+> the exclusions from Recipe 3, or the friction in the 08-03 → 08-12 window looks contextless.
 
 Errors and their surrounding context are the cheap version of "find the friction":
 

--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -32,10 +32,51 @@ Keep that `con` — the recipes below run in the **same `uv run python` session*
 and #2 each rebuild `con` so they stand alone, but #3–#4 reuse the `con` above, and the
 bare-```sql``` recipes (#5–#7) run by wrapping the SQL: `con.execute("""<sql>""").df()`.
 
+**There are two surfaces, not one.** `phoenix.spans` is what the *model* saw and said.
+`<workspace_*>.sandbox_agent_events` is what the *agent* did — tool calls, statuses,
+prompts — across 17 per-workspace schemas. Recipes 1–7 are span recipes; **if your question
+is about tools or agent actions, start at [Recipe 8](#8-what-tools-did-the-agent-actually-run),
+not here.** The two join on `session_id`. See [querying.md](querying.md#the-two-surfaces).
+
 Two conventions used throughout:
 
-- **`ACCT_UUID`** is the JSON path `((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid'` — the per-person identity on a span. It's verbose, so recipes alias it early.
-- **Push work down.** Anything that scans or groups goes inside `postgres_query('pg', $$ … $$)` so Postgres does it. A plain DuckDB scan over 1.2M spans times out.
+- **`ACCT_UUID`** is the per-person identity on a span. **Guard the cast** — as of
+  2026-08-12, 7,421 spans carry `user_api_key_end_user_id` as a raw string rather than a
+  JSON object, and an unguarded `::jsonb` aborts the whole query with
+  `invalid input syntax for type json`:
+
+  ```sql
+  CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%'
+       THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END
+  ```
+
+  Shape breakdown: 67,016 castable JSON objects · 54,958 absent · 7,421 raw strings.
+- **Push work down.** Anything that scans or groups goes inside `postgres_query('pg', $$ … $$)` so Postgres does it.
+
+> **Corpus size (measured 2026-08-12): 129,347 spans, 2026-05-06 → present.** An earlier
+> version of this page said 1.2M and warned that plain DuckDB scans time out. That was
+> accurate when written on 2026-07-15 and stopped being true on **2026-08-03**, when
+> `scripts/debloat_spans.py` (ENG2-1461) deliberately deleted ~1.24M duplicate rows —
+> `raw_gen_ai_request` and pre-May `Claude_Code%` L² children — after archiving them to
+> `~/dal-archive/phoenix-2026-08-03` + S3. Nothing was lost; the DB went 31 GB → 5.5 GB.
+> Scans are fast now. Don't size capacity or cost off the old number.
+
+> **⚠ Two content gaps every content-based recipe must exclude.** Both leave the span row
+> in place with its metadata intact, so counts look healthy while the *text* is gone:
+>
+> | Gap | Window | Filter |
+> |---|---|---|
+> | **litellm redaction** (ENG2-1510) | 2026-08-03 → 2026-08-12 | `attributes::text NOT LIKE '%redacted-by-litellm%'` |
+> | **`dal_trim` dedupe** (ENG2-1469) | historical fat spans, trimmed 2026-08-06 | `... NOT LIKE '%dal_trim%'` |
+>
+> Redaction hit **96–98% of `litellm_request` spans** on 08-04 → 08-11. It was fixed on
+> 2026-08-12 by commit `59c7e14` — same-day spans were 47% redacted as the fix rolled out,
+> and capture after that is healthy. So this is a **bounded historical hole, not an ongoing
+> outage**: `start_time < '2026-08-03'` is clean, and so is anything after 08-12. The
+> `dal_trim` rows point at `llm.input_messages` or the parquet archive for their content.
+>
+> `sandbox_agent_events` is unaffected by both — it's a separate capture path. That's the
+> fallback for any question about the August window ([Recipe 8](#8-what-tools-did-the-agent-actually-run)).
 
 The `account_uuid → person` map lives in `dev_agent_lens/core/identity.yaml` — **gitignored
 (it's PII); copy `identity.example.yaml` and fill it in locally, or get it out-of-band.**
@@ -66,15 +107,21 @@ con.execute(f"ATTACH '{os.environ['PHOENIX_SQL_DATABASE_URL']}' AS pg (TYPE post
 
 roster = con.execute("""
   SELECT * FROM postgres_query('pg', $q$
-    SELECT ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' AS account_uuid,
+    SELECT CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%'
+                THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid'
+           END AS account_uuid,
            count(*) AS spans, max(start_time)::date AS last_seen
     FROM phoenix.spans
     WHERE start_time > now() - INTERVAL '14 days'
     GROUP BY 1 ORDER BY 2 DESC
   $q$)
 """).df()
-# account_uuid = NULL is sandbox VMs (no identity on the span), not a person.
-roster["who"] = roster["account_uuid"].map(lambda a: label_account(a) if a else "sandbox VM")
+# NOTE: account_uuid IS NULL does NOT mean "sandbox VM" — that is backwards, and this
+# page said so until 2026-08-12. Measured: sandbox spans are 13,217 attributed vs 907
+# unattributed (93.6% carry an identity); of the 62,379 unattributed spans, 61,472
+# (98.5%) are laptop traffic. Filtering NULL to isolate sandboxes excludes almost
+# exactly the opposite of what you intend. Detect sandboxes by provenance (Recipe 7).
+roster["who"] = roster["account_uuid"].map(lambda a: label_account(a) if a else "unattributed")
 print(roster.to_string(index=False))
 ```
 
@@ -89,7 +136,7 @@ crash); unresolved uuids render as `(unclaimed:<prefix>)`, so the roster still p
 duckdb -c "INSTALL postgres; LOAD postgres;
 ATTACH '$PHOENIX_SQL_DATABASE_URL' AS pg (TYPE postgres, READ_ONLY);
 SELECT * FROM postgres_query('pg', \$\$
-  SELECT ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' AS account_uuid,
+  SELECT CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END AS account_uuid,
          count(*) AS spans, max(start_time)::date AS last_seen
   FROM phoenix.spans WHERE start_time > now() - INTERVAL '14 days'
   GROUP BY 1 ORDER BY 2 DESC
@@ -116,7 +163,7 @@ spans = con.execute("""
            coalesce(llm_token_count_prompt,0)+coalesce(llm_token_count_completion,0) AS tokens
     FROM phoenix.spans
     WHERE start_time > now() - INTERVAL '30 days'
-      AND ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid'
+      AND CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END
           = '<account-uuid>'   -- a person's uuid, from identity.yaml
   $q$)
 """).df()
@@ -127,8 +174,19 @@ for s in summarize(spans):          # ~46 real sessions, not 1 thread
 
 ## 3. What did they actually type? (human turns, no agent noise)
 
-The prompt text is at the tail of the message array. ~46% of what looks like a user turn is
-the agent talking to itself — `extract_human_turns()` drops it.
+The prompt text is at the tail of the message array. A large share of what looks like a user
+turn is the agent talking to itself — `extract_human_turns()` drops it.
+
+**The drop rate depends on which corpus you're filtering — don't carry one number across:**
+
+| Corpus | Candidate user turns | Genuine human turns | Drop rate |
+|---|---|---|---|
+| `phoenix.spans` text turns (this recipe, pre-08-01, content-bearing) | 9,261 | 5,473 | **40.9%** |
+| Local session JSONLs (`~/.claude/projects/`, 65-day window) | 14,209 | 3,928 | **72%** |
+
+Both measured 2026-08-12. The local JSONLs drop far more because they also carry
+machine-injected "user" events — tool results, system reminders, hook output — that never
+reach the model as a text turn. **Budget sample sizes off the row that matches your source.**
 
 ```python
 from dev_agent_lens.core.prompts import extract_human_turns
@@ -138,7 +196,7 @@ rows = con.execute("""
     SELECT right(attributes->'input'->>'value', 600) AS tail
     FROM phoenix.spans
     WHERE start_time > now() - INTERVAL '30 days'
-      AND ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid'
+      AND CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END
           = '<account-uuid>'
       AND attributes->'input'->>'value' IS NOT NULL
   $q$)
@@ -182,7 +240,7 @@ SELECT * FROM postgres_query('pg', $$
          status_message
   FROM phoenix.spans
   WHERE start_time > now() - INTERVAL '30 days'
-    AND ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid'
+    AND CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END
         = '<account-uuid>'   -- a person's uuid, from identity.yaml
     AND status_code = 'ERROR'
   ORDER BY start_time DESC LIMIT 50
@@ -198,12 +256,12 @@ the *human turns*, not the status codes — grep the recipe-3 output for frustra
 
 ```sql
 SELECT * FROM postgres_query('pg', $$
-  SELECT ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' AS account_uuid,
+  SELECT CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END AS account_uuid,
          start_time::date AS day,
          sum(coalesce(llm_token_count_prompt,0)+coalesce(llm_token_count_completion,0)) AS tokens
   FROM phoenix.spans
   WHERE start_time > now() - INTERVAL '7 days'
-    AND ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' IS NOT NULL
+    AND CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END IS NOT NULL
   GROUP BY 1, 2 ORDER BY 2 DESC, 3 DESC
 $$);
 ```
@@ -224,14 +282,167 @@ SELECT * FROM postgres_query('pg', $$
 $$);
 ```
 
+> **This splits spans by origin — it does not give you sandbox *detail*.** `phoenix.spans`
+> only ever holds what the model saw and said. What the sandboxed agent actually *did* —
+> every tool call, its arguments, its status — lives in
+> `<workspace_*>.sandbox_agent_events`, a different set of schemas entirely. If this recipe
+> is where you landed while looking for agent behaviour, you want
+> [Recipe 8](#8-what-tools-did-the-agent-actually-run).
+>
+> Also note **there are three Phoenix projects**, not one, and a query that ignores them
+> silently blends a dead project into your results:
+>
+> | Project | Spans | Range |
+> |---|---|---|
+> | `sf-workspaces` | 93,078 | 2026-05-15 → present |
+> | `dev-agent-lens` | 36,250 | 2026-05-06 → **2026-06-06 (dead)** |
+> | `default` | 19 | 2026-05-21 |
+>
+> Join through `phoenix.traces` → `phoenix.projects` and filter on `p.name` to scope a
+> query to live traffic.
+
+---
+
+## 8. What tools did the agent actually run?
+
+> **⚠ Start here, and do not reach for `span_kind = 'TOOL'` in `phoenix.spans`.** This is the
+> single most common wrong turn against this corpus, and it has burned an analysis into
+> concluding "we capture zero tool spans" — which is false and was used to argue the agent
+> autonomy ratio wasn't computable.
+>
+> The history matters, because the naive check flips depending on *when* you run it. Until
+> **2026-08-12** `span_kind` held only `LLM` and `UNKNOWN`; a `span_kind='TOOL'` filter
+> returned exactly nothing and read as proof the data was absent. Since the ENG2-1510 capture
+> fix landed, `TOOL` spans *do* exist — but there were only **1,080, all dated 2026-08-12**,
+> against **129,347 spans total**. So the filter now returns a thin, brand-new sliver and
+> still is not the tool record. **The authoritative tool surface has always been
+> `sandbox_agent_events`.**
+
+**Step 1 — find the schemas.** One per workspace project, 17 of them, 11 with data:
+
+```sql
+SELECT * FROM postgres_query('pg', $$
+  SELECT table_schema FROM information_schema.tables
+  WHERE table_name = 'sandbox_agent_events' AND table_schema LIKE 'workspace%'
+  ORDER BY 1
+$$);
+```
+
+> **Quote the schema name.** `workspace_eng2-1376` contains a hyphen, so a bare
+> `workspace_eng2-1376.sandbox_agent_events` is a syntax error (Postgres parses the `-` as
+> subtraction). Always `"workspace_eng2-1376".sandbox_agent_events`. This bites when you
+> build a UNION across all 17 programmatically.
+
+**Step 2 — count what ran.** `session_update_type` separates initiation from status
+transitions, and conflating them roughly 4×s your numbers:
+
+- **`tool_call`** — a tool was invoked. **This is "how many tools ran."** (1,218 total)
+- `tool_call_update` — a status transition on an already-counted call. (4,277 total)
+
+`tool_name`, `tool_call_id` and `status` are **first-class columns** — no JSON digging:
+
+```sql
+SELECT * FROM postgres_query('pg', $$
+  SELECT tool_name, count(*) AS n
+  FROM workspace_uuh_replay.sandbox_agent_events
+  WHERE session_update_type = 'tool_call'
+  GROUP BY 1 ORDER BY 2 DESC
+$$);
+```
+
+Answering the ticket's motivating question — *what tools ran in the UUH replay eval?* —
+that returns `Bash 26, Write 2, Monitor 1`: **29 tool calls** (plus 180 `tool_call_update`
+rows, which is where a "212 tool events" figure comes from).
+
+Fleet-wide, top tools across all 11 populated schemas: `Bash 735 · Read 237 · Edit 85 ·
+mcp__linear-server__get_issue 43 · Write 41`.
+
+The canonical name is also at
+`payload->'params'->'update'->'_meta'->'claudeCode'->>'toolName'`, but **you don't need it** —
+that path and the `tool_name` column agreed on 1,218 of 1,218 `tool_call` rows. Use the
+column; keep the JSON path as a fallback if you hit a row where the column is null.
+
+**Phoenix-side complement.** If you must find tool activity in spans, grep the *content*,
+not `span_kind`:
+
+```sql
+-- the estate is Anthropic-native: /v1/messages ≫ /v1/chat/completions
+attributes->'input'->>'value' LIKE '%tool_use%'      -- the model asked for a tool
+attributes->'input'->>'value' LIKE '%tool_result%'   -- a tool came back
+```
+
+**Do NOT grep `tool_calls`** — that's OpenAI's vocabulary. It matches ~0.25% of this corpus
+and reads as confirmation the data is missing.
+
+---
+
+## 9. What's our autonomy ratio? (inferring the stop signal without `stop_reason`)
+
+The share of turns the agent takes *without* a human typing something is the centerpiece of
+the off-call-human-time program. It is computable today, from spans alone.
+
+**Don't reach for `stop_reason` — it's near-absent.** Only 703 of 129,355 spans carry it
+(0.54%); `sandbox_agent_events` is similar at ~1%. Any recipe gated on it silently returns
+almost nothing.
+
+**You don't need it.** `attributes->'input'->>'value'` holds only the **latest** turn, and
+its shape tells you who initiated:
+
+| Shape of the latest message | Meaning |
+|---|---|
+| `[{'tool_use_id': …, 'type': 'tool_result', …}]` | the agent fed itself a tool result → **continued autonomously** |
+| `[{'type': 'text', 'text': …}]` | a text-initiated turn |
+
+The ratio of the two **is** the autonomy signal:
+
+```sql
+SELECT * FROM postgres_query('pg', $$
+  WITH b AS (
+    SELECT to_char(start_time,'YYYY-MM') AS mon, attributes->'input'->>'value' AS v
+    FROM phoenix.spans
+    WHERE name = 'litellm_request'
+      AND attributes::text NOT LIKE '%redacted-by-litellm%'   -- see the content-gap note
+  )
+  SELECT mon,
+    count(*) FILTER (WHERE v NOT LIKE '%dal_trim%' AND v LIKE '%tool_result%') AS agent_continued,
+    count(*) FILTER (WHERE v NOT LIKE '%dal_trim%' AND v NOT LIKE '%tool_result%'
+                       AND v LIKE '%type%text%')                               AS text_turns
+  FROM b GROUP BY 1 ORDER BY 1
+$$);
+```
+
+**Correct the denominator.** The text bucket is not all human — it includes the agent
+talking to itself. Pass it through `extract_human_turns()` (Recipe 3) before treating it as
+"human turns"; on the span corpus that drops ~41%, which raises the ratio by ~1.7×.
+
+**Measured baseline (2026-08-12), so you have a reference to diff against:**
+
+| Month | agent-continued | text turns | raw ratio | corrected (÷0.59) |
+|---|---|---|---|---|
+| 2026-05 | 3,530 | 2,862 | 1.23 : 1 | ~2.1 : 1 |
+| 2026-06 | 8,938 | 2,375 | 3.76 : 1 | ~6.4 : 1 |
+| 2026-07 | 9,902 | 3,127 | 3.17 : 1 | ~5.4 : 1 |
+| 2026-08 | 516 | 314 | 1.64 : 1 | **unusable** — 97% redacted, tiny surviving sample |
+
+**Cross-check against `sandbox_agent_events`**, which gives an exact per-tool count with no
+redaction exposure and no inference at all (Recipe 8). If the two disagree sharply for a
+window, trust the events table and suspect a content gap in the spans.
+
 ---
 
 ## When a query times out
 
-Supabase enforces a `statement_timeout`, and `attributes` (JSONB) has no index. If a query
-dies with `canceling statement due to statement timeout`:
+Supabase enforces a `statement_timeout`, and `attributes` (JSONB) has no index.
 
-1. **Narrow the window** — 30 days usually completes; 90 usually doesn't.
+**This is much less of a problem than it used to be.** Post-debloat (see the corpus-size
+note at the top), full-corpus scans over all 129k spans — including `attributes::text LIKE`
+predicates — completed in **6–18s** when this page was verified on 2026-08-12. Reach for the
+mitigations below only when you actually hit a timeout, not pre-emptively.
+
+If a query does die with `canceling statement due to statement timeout`:
+
+1. **Narrow the window** — the old guidance was "30 days completes, 90 doesn't"; that was
+   written against a 1.2M-row table and is no longer the binding constraint.
 2. **Narrow the account first** — filter to one `account_uuid` before aggregating.
 3. **Drop `count(DISTINCT …)` over JSON** — it's the most expensive shape and the first to
    time out.

--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -66,7 +66,8 @@ Two conventions used throughout:
   cheaper alternative when your question allows it.
 - **Push work down.** Anything that scans or groups goes inside `postgres_query('pg', $$ … $$)` so Postgres does it.
 
-> **Corpus size (measured 2026-08-12): 129,347 spans, 2026-05-06 → present.** An earlier
+> **Corpus size (measured 2026-08-14): 147,208 spans, 2026-05-06 → present** (~9k/day growth;
+> 129,347 when first measured 2026-08-12). An earlier
 > version of this page said 1.2M and warned that plain DuckDB scans time out. That was
 > accurate when written on 2026-07-15 and stopped being true on **2026-08-03**, when
 > `scripts/debloat_spans.py` (ENG2-1461) deliberately deleted ~1.24M duplicate rows —
@@ -93,7 +94,8 @@ Two conventions used throughout:
 >
 > Redaction hit **90–98% of `litellm_request` spans** on 08-04 → 08-11 (most days 96–98%; 08-09 was 90.2% on a low-volume day). It was fixed on
 > 2026-08-12 by commit `59c7e14` — same-day spans were 47% redacted as the fix rolled out,
-> and capture after that is healthy. So this is a **bounded historical hole, not an ongoing
+> and capture after that is healthy (re-verified 2026-08-14: 0.3% on 08-13, 0.0% on 08-14).
+> So this is a **bounded historical hole, not an ongoing
 > outage**: `start_time < '2026-08-03'` is clean, and so is anything after 08-12. The
 > `dal_trim` rows point at `llm.input_messages` or the parquet archive for their content.
 >
@@ -422,6 +424,12 @@ The canonical name is also at
 that path and the `tool_name` column agreed on 1,218 of 1,218 `tool_call` rows. Use the
 column; keep the JSON path as a fallback if you hit a row where the column is null.
 
+> **Substring searches over `agent_message_chunk` events miss split tokens.** Streaming
+> chunks split words across events — a final reply of `DONE` arrives as `'D'` + `'ONE'`
+> in two rows (observed live, session `ce6da45d`, 2026-08-14). Concatenate a session's
+> chunks in `created_at` order before grepping, or search the harvested session JSONL
+> (which holds the assembled message) instead.
+
 **Phoenix-side complement.** If you must find tool activity in spans, grep the *content*,
 not `span_kind` — and **carry the redaction filter**, or you will reproduce the exact wrong
 conclusion this recipe exists to prevent:
@@ -449,13 +457,14 @@ $$);
 `/v1/messages` ≫ `/v1/chat/completions`). Measured, it matches **0.30%** of `input.value` —
 small enough to read as confirmation the data is missing.
 
-> **This advice is dated 2026-08-12 and will age.** Post-ENG2-1510, Phoenix *is* starting to
-> emit properly-named tool spans (`Claude_Code_Tool_Bash`, `Claude_Code_Tool_Read`, …) under
-> `span_kind='TOOL'`. Today there are too few, over too short a window, to be a usable index —
-> hence content-grepping. **Re-check before relying on this:** if
-> `SELECT min(start_time), max(start_time), count(*) FROM phoenix.spans WHERE span_kind='TOOL'`
-> now spans weeks rather than a single day, prefer querying those spans directly and treat
-> this section as historical.
+> **This advice ages — re-measure before relying on it.** Post-ENG2-1510, Phoenix emits
+> properly-named tool spans (`Claude_Code_Tool_Bash`, `Claude_Code_Tool_Read`, …) under
+> `span_kind='TOOL'`. Re-measured 2026-08-14: **4,721 TOOL spans spanning 2026-08-12 → 08-14**
+> and growing — so for windows entirely after 2026-08-12, `span_kind='TOOL'` is now a usable
+> index. For anything touching earlier data it is still absent by construction (0 spans before
+> 08-12 against a 147k corpus), so use `sandbox_agent_events` or content-grepping there. Also
+> note tool-span **synthesis is proxy-version/tool-dependent** (observed: Bash synthesized,
+> Read not, on some proxies) — `sandbox_agent_events` remains the authoritative count.
 
 ---
 
@@ -522,7 +531,7 @@ the constant.
 | 2026-05 | 240 | 39 | 6.15 : 1 | ~8.8 : 1 |
 | 2026-06 | 8,862 | 2,361 | 3.75 : 1 | ~5.4 : 1 |
 | 2026-07 | 9,902 | 3,127 | 3.17 : 1 | ~4.5 : 1 |
-| 2026-08 | 540 | 328 | 1.65 : 1 | **unusable** — 97% redacted, tiny surviving sample |
+| 2026-08 | 540 | 328 | 1.65 : 1 | **unusable at measurement time** (97% redacted through 08-12); post-08-12 August data is clean — re-measure on a `start_time > '2026-08-12'` window |
 
 **Read the trend with care, and don't headline it.** On live-project traffic the ratio
 *declines* May → July. But May is only 279 classifiable spans (the project had just started;
@@ -539,6 +548,64 @@ a mild decline.** Anyone quoting a May-to-July trend is quoting sampling noise.
 **Cross-check against `sandbox_agent_events`**, which gives an exact per-tool count with no
 redaction exposure and no inference at all (Recipe 8). If the two disagree sharply for a
 window, trust the events table and suspect a content gap in the spans.
+
+---
+
+## 10. Is thinking on, and where's the reasoning text?
+
+> **⚠ Do not detect thinking by grepping `budget_tokens`.** That parameter was **removed from
+> the API on Opus 4.7+** (sending it returns a 400) — only pre-4.6 models (in our fleet:
+> Haiku 4.5) can still legally send it. Grepping it "proves" only Haiku thinks, and
+> `{"type": "adaptive"}` counted as "disabled" completes the inversion. Both produced the
+> false "0.9% thinking-enabled" figure in ENG2-1487. Classify on `thinking.type`:
+
+```sql
+SELECT * FROM postgres_query('pg', $$
+  SELECT coalesce(attributes->'llm'->>'model_name','(null)') AS model,
+         CASE WHEN attributes->'llm'->>'invocation_parameters' ~ '"thinking":\s*\{"type":\s*"adaptive"' THEN 'ON (adaptive)'
+              WHEN attributes->'llm'->>'invocation_parameters' ~ '"thinking":\s*\{"type":\s*"disabled"' THEN 'off (disabled)'
+              WHEN attributes->'llm'->>'invocation_parameters' LIKE '%budget_tokens%' THEN 'ON (budget_tokens, pre-4.6)'
+              ELSE 'absent (model default)' END AS thinking,
+         count(*) AS n
+  FROM phoenix.spans
+  WHERE start_time > now() - INTERVAL '7 days' AND name = 'litellm_request'
+  GROUP BY 1, 2 ORDER BY 3 DESC
+$$);
+```
+
+Verified 2026-08-14: `claude-opus-5` ON (adaptive) 7,027 · off 477 · absent 282 — thinking is
+ON for ~95% of Opus 5 traffic. `absent` means the model's own default applies (Opus 5 /
+Sonnet 5 / Fable default to adaptive).
+
+**Where the reasoning text lives — and the two traps that hid it:**
+
+- Anthropic never returns raw chain of thought. `thinking.display` decides what you get:
+  `"omitted"` (the old fleet default) returns thinking blocks with **empty text but real
+  signatures** — 5,253 such signed-empty blocks accumulated in this store and read as
+  "nothing captured." Since **2026-08-14** the proxy injects `display: "summarized"` on
+  adaptive requests (ENG2-1487, dev-agent-lens PR #64), so summaries flow: **576 spans with
+  reasoning text in the first 90 minutes.**
+- The text lands on the callback-synthesized `Claude_Code_*` spans (`span_kind` **UNKNOWN**,
+  packed `llm` attributes) — **not** on `litellm_request.output_messages`. Scan the whole
+  frame, not LLM-kind rows.
+- Attribute JSON arrives with **escaped quotes** (and dict-repr in some client dataframes) —
+  quote-exact patterns like `'"signature"'` silently match nothing. Use quote-agnostic
+  regexes:
+
+```sql
+SELECT * FROM postgres_query('pg', $$
+  SELECT count(*) FILTER (WHERE attributes::text ~ 'display.{0,4}:\s*.{0,3}summarized') AS asked_for_summary,
+         count(*) FILTER (WHERE attributes::text ~ 'thinking.{0,4}:\s*.{0,3}[A-Za-z][^"\\]{10}') AS has_reasoning_text
+  FROM phoenix.spans
+  WHERE start_time > '2026-08-14'
+$$);
+```
+
+Reasoning-token counts are **not separable**: Anthropic folds thinking into `output_tokens`,
+and `usage_object.reasoning_tokens` is ~always 0 (65 non-zero of 28,578 field-carrying spans).
+"How many tokens went to reasoning?" is not answerable on this path — don't build a report on
+it. Cache accounting IS real: `usage_object.cache_read/creation_input_tokens` non-zero on ~90%
+of carrying spans.
 
 ---
 

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -29,7 +29,8 @@ sandbox run.
 
 **Rules of thumb.** Questions about people, tokens, cost, or prompt text → `phoenix.spans`.
 Questions about tools, agent actions, or anything in the 2026-08-03 → 08-12 redaction window
-→ `sandbox_agent_events`. There is no reliable `span_kind = 'TOOL'` in `phoenix.spans`; see
+→ `sandbox_agent_events`. `span_kind = 'TOOL'` is not a usable tool index here — it was absent entirely until
+2026-08-12 and is still thin and new; see
 [Recipe 8](query-cookbook.md#8-what-tools-did-the-agent-actually-run) before you go looking
 for one.
 
@@ -89,13 +90,13 @@ SELECT 1;"
 ### The one rule that matters: push work down with `postgres_query()`
 
 A plain `SELECT … FROM pg.phoenix.spans` streams every row to your machine and then
-filters — over 1.2M spans it crawls or times out. Wrap aggregates in `postgres_query()`
+filters. Wrap aggregates in `postgres_query()`
 so Postgres does the work and only the summary crosses the wire:
 
 ```sql
 -- who is active, last 14 days
 SELECT * FROM postgres_query('pg', $$
-  SELECT ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' AS account_uuid,
+  SELECT CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END AS account_uuid,
          count(*) AS spans, max(start_time)::date AS last_seen
   FROM phoenix.spans
   WHERE start_time > now() - INTERVAL '14 days'
@@ -148,7 +149,7 @@ spans = con.execute("""
            coalesce(llm_token_count_prompt,0)+coalesce(llm_token_count_completion,0) AS tokens
     FROM phoenix.spans
     WHERE start_time > now() - INTERVAL '30 days'
-      AND ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid'
+      AND CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END
           = '<account-uuid>'   -- resolve a person's uuid(s) via core.identity
   $q$)
 """).df()
@@ -157,9 +158,12 @@ for s in summarize(spans):          # ~46 real sessions, not 1 thread
     print(s.start.date(), f"{s.minutes:.0f}min", s.spans, "spans")
 ```
 
-`extract_human_turns()` matters just as much: ~46% of what parses as a user message is the
-agent talking to itself (`Perform a web search for the query: …`, statusline prompts, tool
-results). Any "what did they ask Claude?" analysis that skips it is roughly half wrong.
+`extract_human_turns()` matters just as much: a large share of what parses as a user message
+is the agent talking to itself (`Perform a web search for the query: …`, statusline prompts,
+tool results). Any "what did they ask Claude?" analysis that skips it is badly wrong. **The
+drop rate is corpus-dependent — 40.9% on `phoenix.spans` vs 72% on the local session JSONLs;
+don't carry one number across.** See
+[query-cookbook.md Recipe 3](query-cookbook.md#3-what-did-they-actually-type-human-turns-no-agent-noise).
 
 ### Known limits (you will hit these)
 
@@ -167,8 +171,10 @@ results). Any "what did they ask Claude?" analysis that skips it is roughly half
   concurrent clients**. Under load you'll see `FATAL: (EMAXCONNSESSION) max clients
   reached`. The transaction pooler (`:6543`) does *not* help — DuckDB needs the session
   pooler's `REPEATABLE READ`. Close DuckDB when idle.
-- **No index on `attributes`.** Aggregates over the JSON identity fields beyond ~30 days
-  hit Supabase's `statement_timeout`. Narrow the window, or narrow the account first.
+- **No index on `attributes`.** This used to mean aggregates beyond ~30 days hit Supabase's
+  `statement_timeout`. Post-debloat (129k spans, not 1.2M) full-corpus scans measured
+  6–18s on 2026-08-12 — narrow the window or the account only if you actually hit a
+  timeout, not pre-emptively.
 
 ---
 

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -8,8 +8,36 @@ Two ways to query the team's Claude Code trace data:
    heavy queries over a source you've pulled down.
 
 Start with (1). It needs nothing but the connection string. For copy-paste recipes that
-answer real questions (who's active, one person's sessions, learning-vs-building, blockers),
-see the [query cookbook](query-cookbook.md).
+answer real questions (who's active, one person's sessions, learning-vs-building, blockers,
+tool usage, autonomy ratio), see the [query cookbook](query-cookbook.md).
+
+---
+
+## The two surfaces
+
+**`phoenix.spans` is not the whole world.** It is one of two capture surfaces in the same
+Postgres, and picking the wrong one is the most expensive mistake you can make against this
+data — it looks like an empty result, not like an error.
+
+| Surface | Holds | Scale (2026-08-12) |
+|---|---|---|
+| `phoenix.spans` | what the **model** saw and said — one `litellm_request` span per model call, JSONB `attributes` | 129,347 spans, 2026-05-06 → present |
+| `<workspace_*>.sandbox_agent_events` | what the **agent did** — tool calls, statuses, prompts; `tool_name` / `tool_call_id` / `status` are first-class columns | 17 schemas (11 populated), 1,218 `tool_call` events |
+
+They join on `session_id`, so "what the model said" lines up with "what the agent did" per
+sandbox run.
+
+**Rules of thumb.** Questions about people, tokens, cost, or prompt text → `phoenix.spans`.
+Questions about tools, agent actions, or anything in the 2026-08-03 → 08-12 redaction window
+→ `sandbox_agent_events`. There is no reliable `span_kind = 'TOOL'` in `phoenix.spans`; see
+[Recipe 8](query-cookbook.md#8-what-tools-did-the-agent-actually-run) before you go looking
+for one.
+
+Two further surfaces exist outside this Postgres and are worth knowing about: the local
+session JSONLs in `~/.claude/projects/` (richest per-session record, pruned ~30 days,
+per-machine) and the parquet archive at `~/dal-archive/phoenix-2026-08-03` + S3 (full
+pre-cleanup span history). See
+[dal-db-learnings-oltp-olap.md](design/dal-db-learnings-oltp-olap.md) for the full inventory.
 
 ---
 

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -24,8 +24,16 @@ data — it looks like an empty result, not like an error.
 | `phoenix.spans` | what the **model** saw and said — one `litellm_request` span per model call, JSONB `attributes` | 129,347 spans, 2026-05-06 → present |
 | `<workspace_*>.sandbox_agent_events` | what the **agent did** — tool calls, statuses, prompts; `tool_name` / `tool_call_id` / `status` are first-class columns | 17 schemas (11 populated), 1,218 `tool_call` events |
 
-They join on `session_id`, so "what the model said" lines up with "what the agent did" per
-sandbox run.
+They join on `session_id` — but **not by the path you would guess.** `session_id` is **not** at `attributes->'metadata'->>'session_id'` — that path returns **0 rows**. It is nested inside the same field the account id lives in:
+
+```sql
+CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%'
+     THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'session_id' END
+```
+
+That resolves on 67,128 spans; 102 of the 117 `sandbox_agent_events` sessions (87%) match.
+
+That lets "what the model said" line up with "what the agent did" per sandbox run.
 
 **Rules of thumb.** Questions about people, tokens, cost, or prompt text → `phoenix.spans`.
 Questions about tools, agent actions, or anything in the 2026-08-03 → 08-12 redaction window
@@ -36,7 +44,8 @@ for one.
 
 Two further surfaces exist outside this Postgres and are worth knowing about: the local
 session JSONLs in `~/.claude/projects/` (richest per-session record, pruned ~30 days,
-per-machine) and the parquet archive at `~/dal-archive/phoenix-2026-08-03` + S3 (full
+per-machine) and the parquet archive at `~/dal-archive/phoenix-2026-08-03` + S3 — that local
+path is per-machine and may not exist on yours; the S3 copy is the durable one — (full
 pre-cleanup span history). See
 [dal-db-learnings-oltp-olap.md](design/dal-db-learnings-oltp-olap.md) for the full inventory.
 
@@ -118,7 +127,9 @@ placeholder `oauth@claude-code.ai`. The `account_uuid → person` map lives in
 from dev_agent_lens.core.identity import label_account, resolve_account
 
 label_account("00000000-0000-0000-0000-000000000001")   # -> 'person-a@example.com'
-resolve_account("00000000-0000-0000-0000-000000000002").email   # -> 'person-b@example.com'
+resolve_account("00000000-0000-0000-0000-000000000002")          # -> Person | None
+# NB: these placeholder uuids are in no real map, so resolve_account() returns None and
+# chaining .email raises AttributeError. Guard it, or use label_account() which never raises.
 ```
 
 Unknown accounts resolve to `None` (never a guess). One person can own several accounts —
@@ -149,8 +160,9 @@ spans = con.execute("""
            coalesce(llm_token_count_prompt,0)+coalesce(llm_token_count_completion,0) AS tokens
     FROM phoenix.spans
     WHERE start_time > now() - INTERVAL '30 days'
+      -- '<account-uuid>': resolve a person's uuid(s) via core.identity
       AND CASE WHEN attributes->'metadata'->>'user_api_key_end_user_id' LIKE '{%' THEN ((attributes->'metadata'->>'user_api_key_end_user_id')::jsonb)->>'account_uuid' END
-          = '<account-uuid>'   -- resolve a person's uuid(s) via core.identity
+          = '<account-uuid>'
   $q$)
 """).df()
 

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -37,8 +37,9 @@ That lets "what the model said" line up with "what the agent did" per sandbox ru
 
 **Rules of thumb.** Questions about people, tokens, cost, or prompt text → `phoenix.spans`.
 Questions about tools, agent actions, or anything in the 2026-08-03 → 08-12 redaction window
-→ `sandbox_agent_events`. `span_kind = 'TOOL'` is not a usable tool index here — it was absent entirely until
-2026-08-12 and is still thin and new; see
+→ `sandbox_agent_events`. `span_kind = 'TOOL'` only exists from 2026-08-12 onward (4,721
+spans by 08-14, growing) — usable for windows after that date, absent by construction before
+it, and synthesis is proxy/tool-dependent; see
 [Recipe 8](query-cookbook.md#8-what-tools-did-the-agent-actually-run) before you go looking
 for one.
 

--- a/tests/core/test_identity.py
+++ b/tests/core/test_identity.py
@@ -95,9 +95,12 @@ class TestResolution:
 
 
 class TestLabels:
-    def test_sandbox_spans_are_labelled_unattributed(self, tmp_path):
+    def test_missing_account_labelled_unattributed_not_sandbox(self, tmp_path):
+        # A missing account_uuid is NOT evidence of a sandbox — that reading is backwards.
+        # Measured 2026-08-12 (ENG2-1509): sandbox spans are 93.6% attributed, and 98.5%
+        # of unattributed spans are laptop traffic. The label must not say "sandbox".
         m = _load(_write(tmp_path, "people: []\nunclaimed: []\n"))
-        assert m.label(None) == "(sandbox/unattributed)"
+        assert m.label(None) == "(unattributed)"
 
     def test_unknown_account_labelled_as_unclaimed_not_blank(self, tmp_path):
         m = _load(_write(tmp_path, "people: []\nunclaimed: []\n"))


### PR DESCRIPTION
Closes ENG2-1509.

An analysis concluded **"DAL has zero tool spans captured"** and that the agent autonomy ratio — the centerpiece of the off-call-human-time program — **was not computable**. Both false, and anyone following the cookbook landed in the same place. The root cause was documentation, not capture.

**Every figure was measured live on 2026-08-12, and every SQL block was executed verbatim before being written down.** This PR then went through adversarial review, which found three blockers — all fixed, described at the bottom.

## New

**Recipe 8 — tool spans.** The authoritative surface is `<workspace_*>.sandbox_agent_events`, not `phoenix.spans`: 17 schemas (11 populated), `tool_name`/`tool_call_id`/`status` as first-class columns. Covers the hyphenated-schema quoting trap (`workspace_eng2-1376`), `tool_call` vs `tool_call_update` (conflating them ~4×s your count), and the `tool_use`/`tool_result` vs OpenAI `tool_calls` vocabulary split.

**Recipe 9 — autonomy signal.** `stop_reason` is near-absent (703 spans, 0.54%) and isn't needed: the shape of the latest turn (`tool_result` vs `text`) *is* the signal. Includes the `extract_human_turns()` correction and a measured monthly baseline.

## Corrections

| Item | Was | Now (measured) |
|---|---|---|
| `account_uuid = NULL` | "sandbox VMs, not a person" | **Inverted.** Sandbox spans 93.6% attributed; 98.5% of unattributed spans are laptop traffic |
| `ACCT_UUID` cast | unguarded `::jsonb` | **Hard-errors on live data** — 7,421 raw-string rows abort the query. Guarded everywhere |
| Corpus size | 1.2M spans | 129,347 — stale since the 2026-08-03 debloat, not data loss |
| Timeout advice | "30d completes, 90d doesn't" | Full scans run 6–18s; demoted to break-glass |
| Human-turn drop rate | one number (~46%) | Corpus-dependent: **40.9%** spans vs **72%** local JSONLs |
| Recipe 7 | implied `phoenix.spans` is the world | Splits by origin only; documents the 3 Phoenix projects |
| Retention | undocumented | Floor is **2026-05-06**; 04-01 → 05-06 is a hard gap on every surface |

Content gaps now in one table: litellm redaction (ENG2-1510, **bounded 2026-08-03 → 08-12**, fixed by `59c7e14`) and `dal_trim` dedupe (ENG2-1469). Carried inline on every content-based recipe.

## Three things that differ from the ticket

1. **`span_kind='TOOL'` now exists.** The ticket says to lead with "there is no `span_kind='TOOL'`". True when filed on 08-11, false the next day — there are now 1,080 TOOL spans, **every one dated 2026-08-12**, appearing after the ENG2-1510 fix. The recipe explains why the naive check flips depending on when you run it, and carries a re-check instruction for when those spans mature into a usable index.
2. **The 72% drop rate is a different corpus.** On `phoenix.spans` — what Recipe 3 actually queries — it's **40.9%**. Writing 72% there would have made it wrong. Both tabled with their corpus.
3. **The "was there a purge?" question is answered in-repo.** `debloat_spans.py` (ENG2-1461) deliberately deleted ~1.24M archived rows on 2026-08-03.

## Scope beyond the ticket

The ticket names two files. A repo-wide sweep found **six** entry points still asserting the corrected claims — a reader could land on the old wrong thing from any of them:

- `markdown_export_pipeline_documentation.md` + `SCHEMA.md` — the `span_kind: LLM, TOOL, CHAIN` myth
- `README.md` — the front-door example carried both the 1.2M figure and the aborting cast
- `identity.example.yaml` — the inverted sandbox claim, in a file the cookbook tells readers to **copy**
- `dal-db-learnings-oltp-olap.md` — inverted claim + stale schema count, in a doc this PR newly links to
- `identity.py` — labelled a missing `account_uuid` as `(sandbox/unattributed)`, printing "sandbox" on rows proven to be 98.5% laptop traffic. Fixed at source; the test pinning the old string now asserts the corrected behaviour. **233 core tests pass.**

## Blockers found in adversarial review, and fixed

Two independent reviewers converged: the corrections were sound, but the page **recreated the failure mode it was written to kill**.

1. **Recipe 9's baseline was contaminated by the dead project** — violating this PR's own Recipe 7 warning four sections later. `dev-agent-lens` supplied 93% of May's rows, dragging May from 6.15:1 to 1.23:1 and **inverting the headline**: published as "autonomy tripled May→July", live traffic says it mildly declined. Now project-filtered, baseline republished, with a caveat that May is only 279 classifiable spans so June→July is the only weight-bearing comparison.
2. **Recipe 8's Phoenix complement had no redaction filter** — following it over August returns 3.5% tool-use against a ~45% baseline, a 13× cliff reproducing the "zero tool spans" conclusion *inside the recipe written to prevent it*. It also wasn't runnable SQL. Both fixed.
3. **`querying.md` was corrected only in its header** while its body held the pre-PR world 60 lines down. Now corrected throughout.

Also caught: the "29 + 180 = 212" reconciliation never closed (212 is `count(*) WHERE tool_call_id IS NOT NULL`), and the cast-guard note never said the raw-string rows live only on 2026-05-21/22 — so a reader testing on a recent window would see no difference and write the guard off.

## Acceptance

Both target questions answered from the cookbook alone, reproducing the documented numbers:

- *What tools ran in the UUH replay eval?* → `Bash 26, Write 2, Monitor 1` — **29 tool calls**
- *What is our autonomy ratio?* → July `9902/3127 = 3.17:1` raw, **≈5.4:1 corrected**

https://claude.ai/code/session_01KRxQLikPc5gcuGfMPiWwGm