### PR TITLE
fix(compose): loopback-bind published ports (ENG2-1521)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   litellm-proxy:
     image: aowen14/litellm-oauth-fix:latest
     ports:
-      - "4000:4000"
+      - "127.0.0.1:4000:4000"
     volumes:
       - ./litellm_config_arize.yaml:/app/config.yaml
     environment:
@@ -47,7 +47,7 @@ services:
   litellm-proxy-phoenix:
     image: aowen14/litellm-oauth-fix:latest
     ports:
-      - "4000:4000"
+      - "127.0.0.1:4000:4000"
     volumes:
       - ./litellm_config_phoenix.yaml:/app/config.yaml
     environment:
@@ -105,8 +105,8 @@ services:
     # arm64 image is fixed.
     platform: linux/amd64
     ports:
-      - "6006:6006" # Phoenix UI
-      - "4317:4317" # OTLP gRPC endpoint
+      - "127.0.0.1:6006:6006" # Phoenix UI
+      - "127.0.0.1:4317:4317" # OTLP gRPC endpoint
     environment:
       - PHOENIX_PORT=6006
       - PHOENIX_HOST=0.0.0.0
@@ -156,7 +156,7 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "4001:4000" # Different port to avoid conflict
+      - "127.0.0.1:4001:4000" # Different port to avoid conflict
     volumes:
       - ./litellm_config.yaml:/app/config.yaml
     environment:
@@ -210,7 +210,7 @@ services:
   litellm-test-arize:
     image: aowen14/litellm-oauth-fix:latest
     ports:
-      - "4100:4000"
+      - "127.0.0.1:4100:4000"
     volumes:
       - ./litellm_config_arize.yaml:/app/config.yaml
     environment:
@@ -244,7 +244,7 @@ services:
   litellm-test-phoenix:
     image: aowen14/litellm-oauth-fix:latest
     ports:
-      - "4101:4000"
+      - "127.0.0.1:4101:4000"
     volumes:
       # Use test-specific config that uses host.docker.internal
       - ./litellm_config_test_phoenix.yaml:/app/config.yaml


### PR DESCRIPTION
Part of ENG2-1521 — the fleet-note stragglers from ENG2-1423 (INCIDENT-2026-07-16 followup).

## What

All 7 published port mappings used the `"4000:4000"` short form, which binds `0.0.0.0` — every interface — not localhost:

| Service | Port |
|---|---|
| `litellm-proxy`, `litellm-proxy-phoenix` | 4000 |
| `litellm-proxy-advanced` | 4001 |
| `litellm-test-arize` / `litellm-test-phoenix` | 4100 / 4101 |
| `phoenix` | 6006 (UI), 4317 (OTLP gRPC) |

That is the shape that let a ransom bot reach a passwordless Postgres over shared WiFi in INCIDENT-2026-07-16 — no router port-forward needed, and a connected VPN does not help (it changes outbound routing; the WiFi interface is still listening).

Postgres in this file is already unpublished, so nothing changes for it.

## One thing to check before merging

If you point a **sandbox VM** at the local Phoenix or litellm, loopback-binding will break that path — an msb guest reaches the host by its tailnet IP, not `127.0.0.1`. The AIT setup routes to the *Fly* litellm over the tailnet rather than this compose, so I believe nothing depends on it, but you'd know better than the file does.

If something does, the fix is to bind the tailnet IP (`tailscale ip -4`) rather than reverting to the short form.

## Verified

YAML parses, 7 services intact. Branched from `origin/main`, so no unrelated work is included.

https://claude.ai/code/session_01X1unXKG4BL91yL8WYb7vFU
