### PR TITLE
fix(capture): content-level testbed assertions + un-hollow the postgres normalize path (ENG2-1487)

### DIFF
--- a/dev_agent_lens/core/schema.py
+++ b/dev_agent_lens/core/schema.py
@@ -11,6 +11,8 @@ Field Mappings:
 
 from __future__ import annotations
 
+import json
+
 from datetime import datetime
 from typing import Any, TypedDict
 
@@ -252,6 +254,46 @@ def _get_column(row: pd.Series, *column_names: str) -> Any:
     return None
 
 
+def _parse_packed_attributes(row: pd.Series) -> dict:
+    """Return the row's `attributes` payload as a dict, or {}.
+
+    The HTTP Phoenix client flattens attributes into dotted columns
+    (`attributes.input.value`), but `PhoenixPostgresClient` and
+    `PhoenixSQLiteClient` return one packed `attributes` column (JSON string
+    or dict). `normalize_phoenix` only read the flattened form, so every
+    content field normalized from the Postgres backend came out None — the
+    database had the content and the unified layer dropped all of it
+    (verified live on rollout session ce6da45d, 2026-08-14: 0/4 LLM rows
+    populated). This fallback closes that gap.
+    """
+    if "attributes" not in row.index:
+        return {}
+    attrs = row["attributes"]
+    if isinstance(attrs, str):
+        try:
+            attrs = json.loads(attrs)
+        except (ValueError, TypeError):
+            return {}
+    return attrs if isinstance(attrs, dict) else {}
+
+
+def _dig(obj: Any, *path: str) -> Any:
+    """Walk nested dict keys; None on any miss."""
+    for key in path:
+        if not isinstance(obj, dict):
+            return None
+        obj = obj.get(key)
+    return None if _is_missing(obj) else obj
+
+
+def _attr(row: pd.Series, packed: dict, dotted: str, *extra_columns: str) -> Any:
+    """Read an attribute by flattened column, packed-dict path, or fallback column."""
+    val = _get_column(row, dotted, *extra_columns)
+    if val is not None:
+        return val
+    return _dig(packed, *dotted.removeprefix("attributes.").split("."))
+
+
 def normalize_phoenix(df: pd.DataFrame) -> pd.DataFrame:
     """
     Convert Phoenix DataFrame to unified schema.
@@ -287,30 +329,39 @@ def normalize_phoenix(df: pd.DataFrame) -> pd.DataFrame:
     for _, row in df.iterrows():
         raw_dict = row.to_dict()  # Preserve all original columns for metadata extraction
         identity_span = {"raw_attributes": raw_dict}
+        # Postgres/SQLite backends pack everything into one `attributes` column;
+        # the HTTP client flattens into dotted columns. _attr reads either shape.
+        packed = _parse_packed_attributes(row)
         unified = {
             "span_id": _safe_str(_get_column(row, "context.span_id")),
             "trace_id": _safe_str(_get_column(row, "context.trace_id")),
             "parent_id": _safe_str(_get_column(row, "parent_id")),
             "name": _safe_str(_get_column(row, "name")),
             "span_kind": _safe_str(
-                _get_column(row, "span_kind", "attributes.openinference.span.kind")
+                _attr(row, packed, "attributes.openinference.span.kind", "span_kind")
             ),
             "start_time": _to_iso8601(_get_column(row, "start_time")),
             "end_time": _to_iso8601(_get_column(row, "end_time")),
             "status_code": _safe_str(_get_column(row, "status_code", "status")),
-            "input_value": _safe_str(_get_column(row, "attributes.input.value")),
-            "output_value": _safe_str(_get_column(row, "attributes.output.value")),
-            "input_messages": _safe_str(_get_column(row, "attributes.llm.input_messages")),
-            "output_messages": _safe_str(_get_column(row, "attributes.llm.output_messages")),
-            "llm_model_name": _safe_str(_get_column(row, "attributes.llm.model_name")),
+            "input_value": _safe_str(_attr(row, packed, "attributes.input.value")),
+            "output_value": _safe_str(_attr(row, packed, "attributes.output.value")),
+            "input_messages": _safe_str(_attr(row, packed, "attributes.llm.input_messages")),
+            "output_messages": _safe_str(_attr(row, packed, "attributes.llm.output_messages")),
+            "llm_model_name": _safe_str(_attr(row, packed, "attributes.llm.model_name")),
             "llm_token_count_prompt": _safe_int(
-                _get_column(row, "attributes.llm.token_count.prompt")
+                # last name: the Postgres/SQLite SELECT exposes this directly
+                _attr(row, packed, "attributes.llm.token_count.prompt", "llm_token_count_prompt")
             ),
             "llm_token_count_completion": _safe_int(
-                _get_column(row, "attributes.llm.token_count.completion")
+                _attr(
+                    row,
+                    packed,
+                    "attributes.llm.token_count.completion",
+                    "llm_token_count_completion",
+                )
             ),
             "llm_token_count_total": _safe_int(
-                _get_column(row, "attributes.llm.token_count.total")
+                _attr(row, packed, "attributes.llm.token_count.total")
             ),
             "user_id": extract_user_id_from_span(identity_span),
             "account_id": extract_account_id_from_span(identity_span),

--- a/dev_agent_lens/testing/orchestrator.py
+++ b/dev_agent_lens/testing/orchestrator.py
@@ -23,6 +23,28 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Sentinel LiteLLM substitutes when it strips request content (ENG2-1510).
+REDACTION_SENTINEL = "redacted-by-litellm"
+
+
+def _column(df: pd.DataFrame, *candidates: str) -> pd.Series | None:
+    """Return the first candidate column present, or None.
+
+    Column naming differs between the Phoenix and Arize dataframes and between
+    the raw and normalized schemas, so content assertions look up by fallback
+    rather than assuming one layout.
+    """
+    for name in candidates:
+        if name in df.columns:
+            return df[name]
+    return None
+
+
+def _nonempty(series: pd.Series) -> pd.Series:
+    """Mask of rows whose text is genuinely populated."""
+    text = series.astype(str).str.strip()
+    return text.ne("") & ~text.isin({"None", "nan", "null", "[]", "{}"})
+
 
 class TestBackend(Enum):
     """Supported observability backends for testing."""
@@ -335,20 +357,37 @@ class TestOrchestrator:
                 self.container.stop()
 
     def _setup_run_directory(self) -> None:
-        """Create run directory with symlinks to shared resources."""
+        """Create run directory with copies of shared resources.
+
+        Copies, not symlinks: Claude Code resolves a symlink to its real path,
+        sees it escaping the run directory (its permission sandbox), and refuses
+        the read — which silently killed the `has_read_tool` smoke assertion
+        (observed live: "sample_code inside this run directory is a symlink …
+        pointing outside this session's working directory").
+        """
+        import shutil
+
         self.run_dir.mkdir(parents=True, exist_ok=True)
 
-        # Symlink shared files
         for shared in [".claude.md", "sample_code"]:
             src = self.testbed_root / shared
             dst = self.run_dir / shared
+            if dst.is_symlink():  # heal run dirs created by the old symlink code
+                dst.unlink()
             if not dst.exists() and src.exists():
-                # Use relative symlink for portability
-                try:
-                    dst.symlink_to(os.path.relpath(src, self.run_dir))
-                except OSError:
-                    # Fall back to absolute path if relative fails
-                    dst.symlink_to(src)
+                if src.is_dir():
+                    shutil.copytree(src, dst)
+                else:
+                    shutil.copy2(src, dst)
+
+        # Per-run nonce for the read-roundtrip assertion. A prompt that asks the
+        # model to read a file whose content is guessable proves nothing: Fable 5
+        # answered `numbers=[1, 2, 3, 4, 5]` from prior knowledge without a single
+        # tool call (run 20260814-121846). A random value the model cannot know
+        # forces the Read AND proves the read content survived into the captured
+        # spans end-to-end.
+        self.nonce = uuid.uuid4().hex[:12]
+        (self.run_dir / "nonce.txt").write_text(f"NONCE={self.nonce}\n")
 
     async def _run_claude_code(self) -> None:
         """Execute Claude Code with print mode in run directory."""
@@ -398,23 +437,45 @@ class TestOrchestrator:
         """Pull traces from test project."""
         from dev_agent_lens.clients import ArizeClient, PhoenixClient
 
-        now = datetime.now()
-        start_time = now - timedelta(minutes=15)
-
-        if self.config.backend == TestBackend.PHOENIX:
-            client = PhoenixClient(project_name=self.project_name)
-            return client.get_spans_dataframe(
-                project_name=self.project_name,
-                start_time=start_time,
-                end_time=now,
-            )
-        else:
+        def fetch() -> pd.DataFrame:
+            now = datetime.now()
+            start_time = now - timedelta(minutes=15)
+            if self.config.backend == TestBackend.PHOENIX:
+                client = PhoenixClient(project_name=self.project_name)
+                return client.get_spans_dataframe(
+                    project_name=self.project_name,
+                    start_time=start_time,
+                    end_time=now,
+                )
             client = ArizeClient(model_id=self.project_name)
             return client.get_spans_dataframe(
                 model_id=self.project_name,
                 start_time=start_time,
                 end_time=now,
             )
+
+        # OTLP export is asynchronous: spans keep arriving for a while after the
+        # claude process exits, and validating on the first fetch races ingestion
+        # (observed live: 4 spans at validation, 14 in the store a minute later —
+        # which made `has_read_tool` flap and skipped the content assertions
+        # entirely). Poll until the count is non-zero AND stable across two
+        # consecutive polls, bounded at ~90s.
+        deadline = asyncio.get_event_loop().time() + 90
+        df = await asyncio.to_thread(fetch)
+        stable = 0
+        while asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(5)
+            newer = await asyncio.to_thread(fetch)
+            if len(newer) > 0 and len(newer) == len(df):
+                stable += 1
+                if stable >= 2:
+                    logger.info("Span count stable at %d; ingestion settled", len(newer))
+                    return newer
+            else:
+                stable = 0
+            df = newer
+        logger.warning("Span ingestion did not settle within 90s; using %d spans", len(df))
+        return df
 
     def _validate(self, spans_df: pd.DataFrame) -> TestResult:
         """Assert expected traces exist."""
@@ -438,10 +499,19 @@ class TestOrchestrator:
         else:
             assertions["has_llm_spans"] = True  # Assume true if we can't check
 
-        # Check for tool spans by name
+        # Check for tool spans by name. Claude_Code_Tool_* spans are SYNTHESIZED by
+        # the litellm callback, and synthesis is version/tool-dependent — observed
+        # live: Bash synthesized in the test container, Read not, nothing at all on
+        # the tailnet proxy. So name assertions only run when synthesis is provably
+        # active (some Tool span exists); the read guarantee itself comes from
+        # read_content_roundtrip above, which doesn't depend on synthesis.
         if "name" in spans_df.columns:
             names = spans_df["name"].astype(str)
-            assertions["has_read_tool"] = names.str.contains("Read", case=False, na=False).any()
+            synthesis_active = names.str.contains("Claude_Code_Tool_", na=False).any()
+            if synthesis_active:
+                assertions["has_read_tool"] = names.str.contains(
+                    "Read", case=False, na=False
+                ).any()
 
             # Check for subagent (Task) tool - only assert if prompt expects it
             has_task = names.str.contains("Task", case=False, na=False).any()
@@ -452,9 +522,8 @@ class TestOrchestrator:
             has_ask_user = names.str.contains("AskUserQuestion", case=False, na=False).any()
             if has_ask_user or "ask_user" in self.config.prompt_file:
                 assertions["has_ask_user_question_tool"] = has_ask_user
-        else:
-            # Can't verify without name column
-            assertions["has_read_tool"] = True
+
+        assertions.update(self._content_assertions(spans_df))
 
         return TestResult(
             test_run_id=self.config.test_run_id,
@@ -462,6 +531,123 @@ class TestOrchestrator:
             assertions=assertions,
             span_count=len(spans_df),
         )
+
+    def _content_assertions(self, spans_df: pd.DataFrame) -> dict[str, bool]:
+        """Assert spans actually carry content, not just that they exist.
+
+        Span *existence* is not capture. Two real defects shipped green against the
+        existence-only assertions above, because both produce perfectly well-formed
+        spans that happen to be hollow:
+
+        * ENG2-1510 — six weeks where ~98% of `input.value` was the literal string
+          `redacted-by-litellm`. Still an LLM span, still had tool names.
+        * The thinking-capture gap — 16,347 adaptive-thinking spans over 30 days with
+          zero thinking content and zero `signature` fields, going back as far as the
+          retention window reaches.
+
+        Each assertion here is gated on the signal being applicable, matching the
+        conditional style used for `has_task_tool` above: an assertion that cannot
+        apply is omitted rather than trivially passed, so a green run means the
+        checks that ran actually verified something.
+        """
+        assertions: dict[str, bool] = {}
+
+        # Read-content roundtrip: the per-run nonce (written by _setup_run_directory,
+        # readable only via the Read tool) must appear somewhere in the captured
+        # spans. This proves in one check that the model actually performed the read
+        # AND that tool/content capture stored it — name-matching a Read span proves
+        # neither. Scans every column: the nonce may land in tool spans, input
+        # messages (tool_result), or output text depending on the capture shape.
+        nonce = getattr(self, "nonce", None)
+        if nonce:
+            assertions["read_content_roundtrip"] = bool(
+                spans_df.astype(str)
+                .apply(lambda col: col.str.contains(nonce, na=False).any())
+                .any()
+            )
+
+        kind = _column(spans_df, "span_kind", "kind")
+        llm_rows = spans_df[kind == "LLM"] if kind is not None else spans_df
+        if llm_rows.empty:
+            return assertions
+
+        inputs = _column(llm_rows, "input_value", "attributes.input.value")
+        if inputs is not None:
+            text = inputs.astype(str)
+            populated = _nonempty(inputs) & ~text.str.contains(REDACTION_SENTINEL, na=False)
+            assertions["llm_input_content_populated"] = bool(populated.any())
+
+        outputs = _column(
+            llm_rows, "output_messages", "output_value", "attributes.llm.output_messages"
+        )
+        if outputs is not None:
+            assertions["llm_output_content_populated"] = bool(_nonempty(outputs).any())
+
+        prompt_tokens = _column(
+            llm_rows, "llm_token_count_prompt", "attributes.llm.token_count.prompt"
+        )
+        if prompt_tokens is not None:
+            counts = pd.to_numeric(prompt_tokens, errors="coerce").fillna(0)
+            assertions["llm_token_counts_populated"] = bool(counts.gt(0).any())
+
+        # The attribute payload arrives in different shapes per client: one raw JSON
+        # string (`raw_attributes`, or `attributes::text` from Postgres), or flattened
+        # `attributes.*` columns holding dicts/JSON-strings (the arize-phoenix client).
+        # Concatenate whatever is present into one searchable blob per row, and keep
+        # every pattern quote-agnostic — nested JSON strings arrive with their quotes
+        # backslash-escaped, and dict cells stringify with single quotes, so a plain
+        # `"summarized"` pattern silently never matches either. (That exact bug hid
+        # case 3 during development; don't reintroduce it.)
+        blob_parts = [
+            series.astype(str)
+            for series in (
+                _column(llm_rows, "raw_attributes", "attributes"),
+                _column(llm_rows, "attributes.usage_object"),
+                _column(llm_rows, "attributes.llm.invocation_parameters"),
+            )
+            if series is not None
+        ]
+        if not blob_parts:
+            return assertions
+        blob = blob_parts[0]
+        for part in blob_parts[1:]:
+            blob = blob + " " + part
+
+        # Cache accounting: only assert once the backend reports the fields at all,
+        # so this doesn't fail on a provider that never emits them. Either field arms
+        # the gate — a span can carry only cache_creation (first write, no read yet).
+        if blob.str.contains(
+            r"cache_(?:read|creation)_input_tokens", na=False, regex=True
+        ).any():
+            assertions["cache_token_breakdown_populated"] = bool(
+                blob.str.contains(
+                    r"cache_(?:read|creation)_input_tokens\\?['\"]?\s*:\s*[1-9]",
+                    na=False,
+                    regex=True,
+                ).any()
+            )
+
+        # Thinking content is only *obtainable* when the request asked for summaries:
+        # with the default `display: "omitted"` the API returns thinking blocks whose
+        # text is empty, so there is genuinely nothing to capture and asserting would
+        # fail for the wrong reason. Gate on the actual `display` PARAMETER — a bare
+        # "summarized" substring false-arms, because invocation_parameters carries the
+        # system prompt and tool descriptions, and ordinary prose contains that word
+        # (live testbed run 20260814-121204 armed exactly that way).
+        if blob.str.contains(
+            r"display\\?['\"]\s*:\s*\\?['\"]summarized", na=False, regex=True
+        ).any():
+            has_thinking = blob.str.contains(
+                # a `signature` *key* (thinking blocks always carry one)…
+                r"['\"]signature\\?['\"]\s*:", na=False, regex=True
+            ) | blob.str.contains(
+                # …or a `thinking` key whose value is a non-empty string (the object
+                # form `"thinking": {…}` in request params deliberately doesn't match)
+                r"thinking\\?['\"]\s*:\s*\\?['\"][^'\"\\]", na=False, regex=True
+            )
+            assertions["thinking_content_captured"] = bool(has_thinking.any())
+
+        return assertions
 
     def cleanup_run_dir(self) -> None:
         """Remove the run directory."""

--- a/tests/e2e/testbed/prompts/minimal.txt
+++ b/tests/e2e/testbed/prompts/minimal.txt
@@ -1,3 +1,9 @@
 PIPELINE_TEST_MODE ACTIVE
 
-Smoke test: Read sample_code/main.py and output "PIPELINE_TEST_COMPLETE".
+Smoke test. Use the Read tool on nonce.txt in the current directory, then answer
+with one line in exactly this form (no other text):
+
+PIPELINE_TEST_COMPLETE <the full NONCE=... line from the file>
+
+The nonce is random and generated per run — it cannot be guessed, so the file
+must actually be read.

--- a/tests/testing/test_content_assertions.py
+++ b/tests/testing/test_content_assertions.py
@@ -1,0 +1,293 @@
+"""
+Unit tests for testbed content assertions (ENG2-1487).
+
+The testbed's original assertions only proved spans *exist* (`has_llm_spans`,
+tool names). Two real capture defects shipped green against them, because both
+produce well-formed but hollow spans:
+
+* ENG2-1510 — six weeks where ~98% of ``input.value`` was the literal string
+  ``redacted-by-litellm``.
+* The thinking-capture gap — 16,347 adaptive-thinking spans over 30 days with
+  zero thinking content stored anywhere in the span.
+
+These tests pin ``_content_assertions`` to catch both, while staying inert
+where a signal genuinely cannot apply (e.g. thinking content when the request
+never asked for summaries).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# Accessed through the module (not imported by name) so pytest doesn't try to
+# collect the production TestOrchestrator/TestConfig classes as test cases.
+from dev_agent_lens.testing import orchestrator as orch
+
+
+def make_orchestrator() -> "orch.TestOrchestrator":
+    o = orch.TestOrchestrator.__new__(orch.TestOrchestrator)
+    o.config = orch.TestConfig(backend=orch.TestBackend.PHOENIX, prompt_file="minimal.txt")
+    return o
+
+
+def assertions_for(rows: list[dict]) -> dict[str, bool]:
+    return make_orchestrator()._content_assertions(pd.DataFrame(rows))
+
+
+HEALTHY = {
+    "span_kind": "LLM",
+    "input_value": "What is 2+2?",
+    "output_messages": '[{"message": {"role": "assistant", "content": "4"}}]',
+    "llm_token_count_prompt": 812,
+    "raw_attributes": '{"usage_object": {"cache_read_input_tokens": 174159}}',
+}
+
+
+# ---------------------------------------------------------------- pass / fail
+
+
+def test_healthy_span_passes_everything():
+    result = assertions_for([HEALTHY])
+    assert result == {
+        "llm_input_content_populated": True,
+        "llm_output_content_populated": True,
+        "llm_token_counts_populated": True,
+        "cache_token_breakdown_populated": True,
+    }
+
+
+def test_redaction_outage_fails_input_content():
+    """ENG2-1510: the redaction sentinel must fail, not count as content."""
+    result = assertions_for([{**HEALTHY, "input_value": "redacted-by-litellm"}])
+    assert result["llm_input_content_populated"] is False
+
+
+def test_empty_and_placeholder_inputs_fail():
+    for hollow in ("", "   ", "None", "nan", "null"):
+        result = assertions_for([{**HEALTHY, "input_value": hollow}])
+        assert result["llm_input_content_populated"] is False, repr(hollow)
+
+
+def test_empty_output_messages_fail():
+    result = assertions_for([{**HEALTHY, "output_messages": "[]"}])
+    assert result["llm_output_content_populated"] is False
+
+
+def test_zero_token_counts_fail():
+    result = assertions_for([{**HEALTHY, "llm_token_count_prompt": 0}])
+    assert result["llm_token_counts_populated"] is False
+
+
+def test_one_populated_span_among_hollow_ones_passes():
+    """The assertion is ANY-populated, not ALL — a single live span proves capture."""
+    result = assertions_for([{**HEALTHY, "input_value": "redacted-by-litellm"}, HEALTHY])
+    assert result["llm_input_content_populated"] is True
+
+
+# ------------------------------------------------------------------ thinking
+
+
+def test_thinking_gap_fails_when_summaries_requested_but_not_stored():
+    """The ENG2-1487 defect: request asked for summaries, span stores none."""
+    row = {
+        **HEALTHY,
+        "raw_attributes": (
+            '{"llm": {"invocation_parameters": '
+            '"{\\"thinking\\": {\\"type\\": \\"adaptive\\", \\"display\\": \\"summarized\\"}}"}}'
+        ),
+    }
+    result = assertions_for([row])
+    assert result["thinking_content_captured"] is False
+
+
+def test_thinking_captured_passes_escaped_json_form():
+    row = {
+        **HEALTHY,
+        "raw_attributes": (
+            '{"invocation_parameters": "{\\"display\\": \\"summarized\\"}", '
+            '"output": "[{\\"type\\": \\"thinking\\", '
+            '\\"thinking\\": \\"Let me work through this\\", \\"signature\\": \\"abc\\"}]"}'
+        ),
+    }
+    result = assertions_for([row])
+    assert result["thinking_content_captured"] is True
+
+
+def test_thinking_captured_passes_dict_repr_form():
+    """Flattened arize-phoenix columns stringify as python dicts (single quotes)."""
+    row = {
+        "span_kind": "LLM",
+        "attributes.input.value": "hello",
+        "attributes.llm.invocation_parameters": "{'thinking': {'display': 'summarized'}}",
+        "attributes.usage_object": {
+            "cache_read_input_tokens": 5000,
+            "content": [{"type": "thinking", "thinking": "Consider the", "signature": "xyz"}],
+        },
+    }
+    result = assertions_for([row])
+    assert result["thinking_content_captured"] is True
+
+
+def test_request_param_object_form_is_not_content():
+    """`"thinking": {…}` in request params must not satisfy the content check."""
+    row = {
+        **HEALTHY,
+        "raw_attributes": (
+            '{"invocation_parameters": "{\\"thinking\\": {\\"type\\": \\"adaptive\\", '
+            '\\"display\\": \\"summarized\\"}}", "output": "the answer is 4"}'
+        ),
+    }
+    result = assertions_for([row])
+    assert result["thinking_content_captured"] is False
+
+
+def test_thinking_assertion_inert_without_summarized_request():
+    """Today's fleet shape: adaptive + display omitted -> nothing to capture, no gate."""
+    row = {
+        **HEALTHY,
+        "raw_attributes": (
+            '{"invocation_parameters": "{\\"thinking\\": {\\"type\\": \\"adaptive\\"}}", '
+            '"usage_object": {"cache_read_input_tokens": 174159}}'
+        ),
+    }
+    result = assertions_for([row])
+    assert "thinking_content_captured" not in result
+    assert result["cache_token_breakdown_populated"] is True
+
+
+# --------------------------------------------------------------------- cache
+
+
+def test_all_zero_cache_tokens_fail():
+    row = {
+        **HEALTHY,
+        "raw_attributes": (
+            '{"usage_object": {"cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}}'
+        ),
+    }
+    result = assertions_for([row])
+    assert result["cache_token_breakdown_populated"] is False
+
+
+def test_cache_assertion_inert_when_fields_absent():
+    result = assertions_for([{**HEALTHY, "raw_attributes": "{}"}])
+    assert "cache_token_breakdown_populated" not in result
+
+
+def test_cache_matches_dict_repr_cells():
+    row = {
+        "span_kind": "LLM",
+        "attributes.input.value": "hello",
+        "attributes.usage_object": {"cache_creation_input_tokens": 53454},
+    }
+    result = assertions_for([row])
+    assert result["cache_token_breakdown_populated"] is True
+
+
+# ------------------------------------------------------------ gating / shape
+
+
+def test_no_llm_rows_yields_no_assertions():
+    result = assertions_for([{"span_kind": "TOOL", "input_value": "x"}])
+    assert result == {}
+
+
+def test_missing_columns_yield_no_assertions_but_no_crash():
+    result = assertions_for([{"span_kind": "LLM"}])
+    assert result == {}
+
+
+def test_flattened_phoenix_columns_are_recognized():
+    """The arize-phoenix client returns attributes.* columns, not our schema names."""
+    row = {
+        "span_kind": "LLM",
+        "attributes.input.value": "What is 2+2?",
+        "attributes.llm.output_messages": [{"role": "assistant", "content": "4"}],
+        "attributes.llm.token_count.prompt": 812.0,
+    }
+    result = assertions_for([row])
+    assert result["llm_input_content_populated"] is True
+    assert result["llm_output_content_populated"] is True
+    assert result["llm_token_counts_populated"] is True
+
+
+def test_kind_column_variant_is_honored():
+    """Arize dataframes use `kind` instead of `span_kind`."""
+    result = assertions_for([{**{k: v for k, v in HEALTHY.items() if k != "span_kind"}, "kind": "LLM"}])
+    assert result["llm_input_content_populated"] is True
+
+
+def test_prose_summarized_does_not_arm_the_gate():
+    """The word 'summarized' in system-prompt/tool text (which rides inside
+    invocation_parameters) must not arm the gate — only the display PARAMETER.
+    Live testbed run 20260814-121204 false-armed exactly this way."""
+    row = {
+        **HEALTHY,
+        "raw_attributes": (
+            '{"invocation_parameters": "{\\"system\\": \\"context is summarized when '
+            'long\\", \\"thinking\\": {\\"type\\": \\"adaptive\\", '
+            '\\"display\\": \\"omitted\\"}}"}'
+        ),
+    }
+    result = assertions_for([row])
+    assert "thinking_content_captured" not in result
+
+
+def test_normalize_phoenix_handles_packed_attributes():
+    """PhoenixPostgresClient returns one packed `attributes` JSON column; the
+    normalizer must populate content fields from it (it used to emit all-None —
+    proven live on rollout session ce6da45d, 0/4 LLM rows populated)."""
+    import json as _json
+
+    from dev_agent_lens.core.schema import normalize_phoenix
+
+    packed = {
+        "input": {"value": "probe input"},
+        "output": {"value": "probe output"},
+        "llm": {
+            "model_name": "claude-opus-5",
+            "output_messages": [{"message": {"role": "assistant", "content": "DONE"}}],
+            "token_count": {"prompt": 316000, "completion": 55},
+        },
+        "openinference": {"span": {"kind": "LLM"}},
+    }
+    df = pd.DataFrame(
+        [
+            {
+                "context.span_id": "abc",
+                "context.trace_id": "def",
+                "parent_id": None,
+                "name": "litellm_request",
+                "span_kind": "LLM",
+                "start_time": "2026-08-14T17:19:13Z",
+                "end_time": "2026-08-14T17:19:25Z",
+                "status_code": "OK",
+                "attributes": _json.dumps(packed),  # packed, exactly as postgres client emits
+                "llm_token_count_prompt": 316000,
+            }
+        ]
+    )
+    out = normalize_phoenix(df)
+    row = out.iloc[0]
+    assert row["input_value"] == "probe input"
+    assert row["output_value"] == "probe output"
+    assert row["llm_model_name"] == "claude-opus-5"
+    assert row["llm_token_count_prompt"] == 316000
+    assert row["llm_token_count_completion"] == 55
+    assert "DONE" in row["output_messages"]
+    # and the content assertions pass over the normalized frame
+    assert assertions_for(out.to_dict("records"))["llm_input_content_populated"] is True
+
+
+def test_read_roundtrip_nonce_assertion():
+    """Nonce present anywhere in the spans -> True; absent -> False; no nonce set -> inert."""
+    o = make_orchestrator()
+    df_hit = pd.DataFrame([{**HEALTHY, "output_messages": "PIPELINE_TEST_COMPLETE NONCE=cafe0123beef"}])
+    df_miss = pd.DataFrame([HEALTHY])
+
+    o.nonce = "cafe0123beef"
+    assert o._content_assertions(df_hit)["read_content_roundtrip"] is True
+    assert o._content_assertions(df_miss)["read_content_roundtrip"] is False
+
+    o.nonce = None
+    assert "read_content_roundtrip" not in o._content_assertions(df_hit)


### PR DESCRIPTION
## What

Two halves, both verified live (full evidence on [ENG2-1487](https://linear.app/teraflop/issue/ENG2-1487)):

**1. The testbed now asserts span CONTENT, not just span existence.** The old assertions (`has_llm_spans` + tool names) passed on completely hollow spans — which is how six weeks of `redacted-by-litellm` inputs (ENG2-1510) and the thinking-content gap both shipped green. New: input populated and not the redaction sentinel, output non-empty, token counts > 0, cache breakdown non-zero when reported, thinking content required iff `display: "summarized"` was requested, and a per-run **nonce roundtrip** — a random file the model must read, whose value must reappear in captured spans. Getting the testbed green surfaced and fixed four more real bugs: a run-dir symlink claude refuses to read through, validation racing async OTLP ingestion, a smoke prompt Fable 5 could satisfy from prior knowledge without any tool call, and `Claude_Code_Tool_*` name assertions depending on callback synthesis that is version/tool-dependent.

**2. `normalize_phoenix` no longer drops all content from the Postgres backend.** It only read flattened `attributes.*` columns; `PhoenixPostgresClient` returns one packed `attributes` JSON column. Every content field of a phoenix-postgres `dal sync` came out None. Proven on live prod rows (rollout session `ce6da45d`): **0/4 LLM rows populated before, 4/4 after, same rows.** Historical unified exports made through this backend are hollow and need re-syncing.

## Testing

- 21 new unit tests (`tests/testing/test_content_assertions.py`)
- `dal run testbed --prompt minimal.txt` → **PASSED** (6 assertions, real spans through the real proxy)
- Cross-surface audit on a live captured rollout: ACP events, phoenix spans, and the DAL extraction path all content-verified
- 17 pre-existing suite failures byte-identical with/without this change (stash-diffed)

## Note for reviewers

Every pattern here is quote-agnostic deliberately: nested attribute JSON arrives with escaped quotes, dict cells stringify with single quotes. Quote-exact patterns silently never match — that bug produced two false "no thinking content" conclusions before being caught.

https://claude.ai/code/session_01X1unXKG4BL91yL8WYb7vFU
