### PR TITLE
feat(capture): thinking summaries fleet-wide via proxy pre-call hook (ENG2-1487)

### DIFF
--- a/dev_agent_lens/testing/orchestrator.py
+++ b/dev_agent_lens/testing/orchestrator.py
@@ -590,6 +590,35 @@ class TestOrchestrator:
             counts = pd.to_numeric(prompt_tokens, errors="coerce").fillna(0)
             assertions["llm_token_counts_populated"] = bool(counts.gt(0).any())
 
+        # Thinking blocks ride on the callback-synthesized Claude_Code_* spans,
+        # whose span_kind is UNKNOWN — so the thinking gate must scan the WHOLE
+        # frame, not just LLM rows (live run 20260814-134530: summaries present,
+        # LLM-scoped blob missed them).
+        full_parts = [
+            series.astype(str)
+            for series in (
+                _column(spans_df, "raw_attributes", "attributes"),
+                _column(spans_df, "attributes.llm"),
+                _column(spans_df, "attributes.usage_object"),
+                _column(spans_df, "attributes.output.value"),
+                _column(spans_df, "attributes.llm.invocation_parameters"),
+            )
+            if series is not None
+        ]
+        if full_parts:
+            full_blob = full_parts[0]
+            for part in full_parts[1:]:
+                full_blob = full_blob + " " + part
+            if full_blob.str.contains(
+                r"display\\?['\"]\s*:\s*\\?['\"]summarized", na=False, regex=True
+            ).any():
+                has_thinking = full_blob.str.contains(
+                    r"['\"]signature\\?['\"]\s*:", na=False, regex=True
+                ) | full_blob.str.contains(
+                    r"thinking\\?['\"]\s*:\s*\\?['\"][^'\"\\]", na=False, regex=True
+                )
+                assertions["thinking_content_captured"] = bool(has_thinking.any())
+
         # The attribute payload arrives in different shapes per client: one raw JSON
         # string (`raw_attributes`, or `attributes::text` from Postgres), or flattened
         # `attributes.*` columns holding dicts/JSON-strings (the arize-phoenix client).
@@ -603,6 +632,10 @@ class TestOrchestrator:
             for series in (
                 _column(llm_rows, "raw_attributes", "attributes"),
                 _column(llm_rows, "attributes.usage_object"),
+                # packed llm dict: the arize-phoenix client keeps thinking blocks
+                # (incl. summaries + signatures) here, not in the dotted columns —
+                # verified live on run 20260814-134345
+                _column(llm_rows, "attributes.llm"),
                 _column(llm_rows, "attributes.llm.invocation_parameters"),
             )
             if series is not None
@@ -627,25 +660,6 @@ class TestOrchestrator:
                 ).any()
             )
 
-        # Thinking content is only *obtainable* when the request asked for summaries:
-        # with the default `display: "omitted"` the API returns thinking blocks whose
-        # text is empty, so there is genuinely nothing to capture and asserting would
-        # fail for the wrong reason. Gate on the actual `display` PARAMETER — a bare
-        # "summarized" substring false-arms, because invocation_parameters carries the
-        # system prompt and tool descriptions, and ordinary prose contains that word
-        # (live testbed run 20260814-121204 armed exactly that way).
-        if blob.str.contains(
-            r"display\\?['\"]\s*:\s*\\?['\"]summarized", na=False, regex=True
-        ).any():
-            has_thinking = blob.str.contains(
-                # a `signature` *key* (thinking blocks always carry one)…
-                r"['\"]signature\\?['\"]\s*:", na=False, regex=True
-            ) | blob.str.contains(
-                # …or a `thinking` key whose value is a non-empty string (the object
-                # form `"thinking": {…}` in request params deliberately doesn't match)
-                r"thinking\\?['\"]\s*:\s*\\?['\"][^'\"\\]", na=False, regex=True
-            )
-            assertions["thinking_content_captured"] = bool(has_thinking.any())
 
         return assertions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - "127.0.0.1:4000:4000"
     volumes:
       - ./litellm_config_phoenix.yaml:/app/config.yaml
+      - ./thinking_display_hook.py:/app/thinking_display_hook.py
     environment:
       # Anthropic + runtime
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
@@ -248,6 +249,7 @@ services:
     volumes:
       # Use test-specific config that uses host.docker.internal
       - ./litellm_config_test_phoenix.yaml:/app/config.yaml
+      - ./thinking_display_hook.py:/app/thinking_display_hook.py
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
 

--- a/fly/litellm.fly.toml
+++ b/fly/litellm.fly.toml
@@ -97,6 +97,13 @@ primary_region = "iad"
   guest_path = "/app/config.yaml"
   local_path = "fly/litellm_config_fly.yaml"
 
+# Thinking-summaries hook (ENG2-1487): forces display="summarized" on adaptive
+# requests so reasoning text lands in Phoenix. Rollback = drop the callback
+# entry in litellm_config_fly.yaml and redeploy.
+[[files]]
+  guest_path = "/app/thinking_display_hook.py"
+  local_path = "thinking_display_hook.py"
+
 [processes]
   # Mirrors the docker-compose command for litellm-proxy-phoenix.
   # --host :: makes uvicorn bind dual-stack instead of IPv4-only; without

--- a/fly/litellm_config_fly.yaml
+++ b/fly/litellm_config_fly.yaml
@@ -65,7 +65,7 @@ model_list:
       custom_llm_provider: "anthropic"
 
 litellm_settings:
-  callbacks: ["arize_phoenix"]
+  callbacks: ["arize_phoenix", "thinking_display_hook.proxy_handler_instance"]
   drop_params: false
   set_verbose: false
   pass_through_params: true

--- a/litellm_config_phoenix.yaml
+++ b/litellm_config_phoenix.yaml
@@ -55,7 +55,7 @@ model_list:
 
 litellm_settings:
   # Enable Arize Phoenix callbacks for local observability
-  callbacks: ["arize_phoenix"]
+  callbacks: ["arize_phoenix", "thinking_display_hook.proxy_handler_instance"]
 
   # Don't drop any parameters - preserve everything Claude Code sends
   drop_params: false

--- a/litellm_config_test_phoenix.yaml
+++ b/litellm_config_test_phoenix.yaml
@@ -13,7 +13,7 @@ model_list:
       api_key: os.environ/ANTHROPIC_API_KEY
 
 litellm_settings:
-  callbacks: ["arize_phoenix"]
+  callbacks: ["arize_phoenix", "thinking_display_hook.proxy_handler_instance"]
   drop_params: false
   set_verbose: true
   pass_through_params: true

--- a/tests/testing/test_content_assertions.py
+++ b/tests/testing/test_content_assertions.py
@@ -291,3 +291,20 @@ def test_read_roundtrip_nonce_assertion():
 
     o.nonce = None
     assert "read_content_roundtrip" not in o._content_assertions(df_hit)
+
+
+def test_thinking_summary_in_packed_llm_column_passes():
+    """arize-phoenix stores thinking blocks inside the packed `attributes.llm`
+    dict cell, not the dotted columns (live run 20260814-134345)."""
+    row = {
+        "span_kind": "LLM",
+        "attributes.input.value": "hello",
+        "attributes.llm": {
+            "invocation_parameters": '{"thinking": {"type": "adaptive", "display": "summarized"}}',
+            "output_messages": [
+                {"contents": [{"type": "thinking", "thinking": "Reading the nonce file", "signature": "xyz"}]}
+            ],
+        },
+    }
+    result = assertions_for([row])
+    assert result["thinking_content_captured"] is True

--- a/thinking_display_hook.py
+++ b/thinking_display_hook.py
@@ -1,0 +1,46 @@
+"""Force thinking summaries on adaptive-thinking requests (ENG2-1487).
+
+Anthropic never returns raw chain-of-thought; `thinking.display` decides whether
+you get a readable summary ("summarized") or empty-text thinking blocks
+("omitted", the default every client sends). Fleet decision 2026-08-14 (Adam):
+summaries ON — so reasoning text lands in Phoenix instead of empty blocks.
+
+Scope guards:
+- Only touches `thinking: {"type": "adaptive"}` requests. `disabled` stays
+  disabled (also: display on a disabled block is invalid), and pre-4.6
+  `{"type": "enabled", budget_tokens: N}` requests are left alone — `display`
+  doesn't exist on those models and could 400.
+- Overwrites an explicit `display: "omitted"` deliberately: that's client
+  plumbing default, and the fleet decision is summaries on.
+
+Registered in the litellm config as:
+    callbacks: ["arize_phoenix", "thinking_display_hook.proxy_handler_instance"]
+The module must sit next to the proxy's cwd (/app in both the fly image and the
+compose containers).
+
+Rollback: remove the callback entry, restart the proxy.
+"""
+
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_logger import CustomLogger
+
+
+class ThinkingDisplayHook(CustomLogger):
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        try:
+            thinking = data.get("thinking") if isinstance(data, dict) else None
+            if isinstance(thinking, dict) and thinking.get("type") == "adaptive":
+                if thinking.get("display") != "summarized":
+                    data["thinking"] = {**thinking, "display": "summarized"}
+                    verbose_proxy_logger.debug(
+                        "[thinking_display_hook] set display=summarized "
+                        "(was %r, call_type=%s)",
+                        thinking.get("display"),
+                        call_type,
+                    )
+        except Exception as exc:  # never break a request over an observability knob
+            verbose_proxy_logger.warning("[thinking_display_hook] skipped: %s", exc)
+        return data
+
+
+proxy_handler_instance = ThinkingDisplayHook()


### PR DESCRIPTION
Forces `display: "summarized"` on adaptive-thinking requests at the LiteLLM proxy, so reasoning summaries land in Phoenix instead of empty signed blocks. Scope-guarded (adaptive only; disabled and budget_tokens untouched), fails open, rollback = drop the callback entry.

**Already deployed to sf-litellm and verified live**: prod `litellm_request` carries `display=summarized`, summary text stored, span sizes healthy (avg 11KB). Testbed's `thinking_content_captured` gate armed automatically and all six assertions PASS; 22 unit tests.

Full evidence trail on [ENG2-1487](https://linear.app/teraflop/issue/ENG2-1487).

https://claude.ai/code/session_01X1unXKG4BL91yL8WYb7vFU