### PR TITLE
Pin Phoenix image by digest (9h outage postmortem)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,10 @@ services:
 
   # Phoenix observability server (use with --profile phoenix)
   phoenix:
-    image: arizephoenix/phoenix:latest
+    # PINNED (2026-08-20). Migrations run on every start and are forward-only.
+    # With PHOENIX_SQL_DATABASE_URL set this container migrates the SHARED
+    # Supabase schema -- a :latest pull here took sf-phoenix down for ~9h.
+    image: arizephoenix/phoenix@sha256:b966eeed832d319a779a89fc6aa642924a82c4eff00c8974b23a0d224e8c3bb4
     # arizephoenix/phoenix:latest's linux/arm64 build crashes on Apple Silicon
     # with SIGILL (exit 132) before producing any log output. The linux/amd64
     # build runs fine under Rosetta emulation. Pin platform until the upstream

--- a/fly/phoenix.fly.toml
+++ b/fly/phoenix.fly.toml
@@ -22,7 +22,12 @@ app = "sf-phoenix"
 primary_region = "iad"
 
 [build]
-  image = "arizephoenix/phoenix:latest"
+  # PINNED (2026-08-20). Phoenix runs alembic migrations on every start and they
+  # are forward-only. On 2026-08-20 a newer image migrated the SHARED Supabase
+  # schema to an unreleased revision (4aad9107d196) and sf-phoenix could not start
+  # for ~9h. Any Phoenix pointed at PHOENIX_SQL_DATABASE_URL can do this. Do not
+  # move this back to :latest -- bump the digest deliberately, together.
+  image = "arizephoenix/phoenix@sha256:b966eeed832d319a779a89fc6aa642924a82c4eff00c8974b23a0d224e8c3bb4"
 
 [env]
   PHOENIX_PORT = "6006"


### PR DESCRIPTION
Phoenix runs alembic migrations on **every start**, and they're forward-only.

On 2026-08-20 a newer image migrated the **shared Supabase schema** to an unreleased revision (`4aad9107d196`). `sf-phoenix` had been running 16.0.0, couldn't locate that revision, crash-looped 10 times and Fly gave up. Down ~9 hours (05:27–14:43 UTC).

The vector isn't Fly. Every Phoenix pointed at `PHOENIX_SQL_DATABASE_URL` shares one schema, and this repo's compose documents exactly that. So a local `docker compose --profile phoenix up` on `:latest` can take production down.

Pins every reference to the digest `sf-phoenix` is currently running. Bump it deliberately, in all three places at once.

Note: that digest is a nightly build. It's the only image that matches the current schema — stable 20.3.0 was tested and still fails. Moving back to a stable tag needs a DB downgrade.

Two follow-ups not in this PR: `capture-health.yml` stayed green through the whole outage (all four checks hit Postgres directly, never ask whether Phoenix is serving), and the telemetry hooks fail silently by design, so nothing alerted.

https://claude.ai/code/session_01R8Q57BUitd32B9jxUL6j83