### PR TITLE
feat(export): Claude Code session JSONL -> ATIF -> Phoenix

### DIFF
--- a/dev_agent_lens/cli/main.py
+++ b/dev_agent_lens/cli/main.py
@@ -4458,6 +4458,140 @@ def export_events(
     click.echo(f"Output: {result.output_path}")
 
 
+@main.command("export-atif")
+@click.argument("source", type=click.Path(exists=True))
+@click.option(
+    "--output",
+    "-o",
+    "output_path",
+    type=str,
+    required=True,
+    help="Output path for the ATIF JSON (a list of trajectories)",
+)
+def export_atif(source, output_path):
+    """Convert Claude Code session JSONL to ATIF trajectories.
+
+    SOURCE is a single .jsonl session file, or a directory of them. For a
+    directory, each `agent-<agentId>.jsonl` sidechain is embedded in its
+    parent's `subagent_trajectories` and referenced from the Task observation
+    that spawned it, so the subagent spans nest correctly downstream.
+
+    \b
+    Examples:
+        dal export-atif ~/.claude/projects/<encoded-repo> -o traj.json
+        dal export-atif session.jsonl -o traj.json
+    """
+    import json
+    from pathlib import Path
+
+    from dev_agent_lens.export.atif import session_file_to_atif, session_tree_to_atif
+
+    src = Path(source)
+    if src.is_dir():
+        trajectories, stats = session_tree_to_atif(src)
+    else:
+        trajectory, stats = session_file_to_atif(src)
+        trajectories = [trajectory]
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(trajectories))
+
+    subagents = sum(len(t.get("subagent_trajectories", [])) for t in trajectories)
+    click.echo(f"Trajectories: {len(trajectories)}")
+    click.echo(f"Steps: {sum(len(t['steps']) for t in trajectories):,}")
+    click.echo(f"Tool calls: {stats['tool_calls']:,}")
+    if subagents:
+        click.echo(f"Subagents embedded: {subagents} (linked: {stats['subagent_linked']})")
+    if stats.get("subagent_transcript_missing"):
+        click.echo(
+            click.style(
+                f"Task calls with no transcript in SOURCE: "
+                f"{stats['subagent_transcript_missing']}",
+                fg="yellow",
+            )
+        )
+    if stats.get("orphan_tool_result"):
+        click.echo(
+            click.style(f"Orphan tool results: {stats['orphan_tool_result']}", fg="yellow")
+        )
+    click.echo(f"Output: {out}")
+
+
+@main.command("push-atif")
+@click.argument("trajectories_path", type=click.Path(exists=True))
+@click.option("--endpoint", required=True, help="OTLP HTTP base URL, e.g. http://127.0.0.1:6006")
+@click.option("--project", required=True, help="Destination project name")
+@click.option("--user", "user_id", default=None, help="Stamp user.id on every span")
+@click.option(
+    "--chunk-size",
+    type=int,
+    default=100,
+    help="Spans per request (default: 100). Large requests are dropped by a full queue.",
+)
+@click.option("--pause", type=float, default=1.0, help="Seconds between requests (default: 1.0)")
+@click.option("--dry-run", is_flag=True, help="Convert and validate without sending")
+def push_atif(trajectories_path, endpoint, project, user_id, chunk_size, pause, dry_run):
+    """Push ATIF trajectories to an OTLP backend (Phoenix).
+
+    Safe to re-run: trace and span ids are derived deterministically, so spans
+    that already landed are no-ops.
+
+    A finished push means every chunk was ACCEPTED, which is not the same as
+    stored -- the backend enqueues and answers before it writes. Confirm by
+    counting rows in the backing store.
+
+    \b
+    Example:
+        dal push-atif traj.json --endpoint http://127.0.0.1:6006 \\
+            --project claude-code-sessions --user alice
+    """
+    import json
+    from pathlib import Path
+
+    from dev_agent_lens.export.otlp import push_trajectories
+
+    trajectories = json.loads(Path(trajectories_path).read_text())
+    try:
+        result = push_trajectories(
+            endpoint=endpoint,
+            trajectories=trajectories,
+            project=project,
+            user_id=user_id,
+            chunk_size=chunk_size,
+            pause=pause,
+            dry_run=dry_run,
+        )
+    except (ImportError, ValueError) as exc:
+        click.echo(click.style(str(exc), fg="red"))
+        raise SystemExit(1)
+
+    click.echo(f"Spans: {result.spans_total:,}")
+    if result.clamped_spans:
+        click.echo(f"Clamped (end before start): {result.clamped_spans}")
+    if dry_run:
+        click.echo("Dry run: nothing sent")
+        return
+    click.echo(f"Accepted: {result.spans_sent:,} in {result.requests:,} requests")
+    if result.retries_503:
+        click.echo(f"Backoff waits (queue full): {result.retries_503}")
+    if not result.complete:
+        click.echo(
+            click.style(
+                f"INCOMPLETE: {result.failed_chunks} failed, "
+                f"{result.exhausted_chunks} gave up. Re-run to fill the gaps.",
+                fg="red",
+            )
+        )
+        raise SystemExit(1)
+    click.echo(
+        click.style(
+            "All chunks accepted. Verify persistence by counting rows in the backend.",
+            fg="green",
+        )
+    )
+
+
 @main.command("query-events")
 @click.option(
     "--source",

--- a/dev_agent_lens/export/atif.py
+++ b/dev_agent_lens/export/atif.py
@@ -1,0 +1,252 @@
+"""
+ATIF export for Claude Code sessions.
+
+Converts a Claude Code session JSONL into an ATIF-v1.7 trajectory
+(https://github.com/Teraflop-Inc/harbor rfcs/0001-trajectory-format), which
+`harbor-atif2otel` then converts to OpenTelemetry spans for Phoenix or any
+OTLP backend.
+
+Why this exists: `harbor-atif2otel` accepts ATIF only, so eval trajectories
+could already be backfilled but raw session JSONL could not. This is the
+missing mapping layer.
+
+Verified 2026-08-21 against a real 8.5 MB session: 1029 steps, valid ATIF,
+1359 spans in Phoenix with span kinds intact and original timestamps preserved
+(Aug 4-5, not ingestion date).
+
+Three fidelity limits, measured, that callers should know about:
+
+  * Reasoning text is NOT recoverable. Claude Code writes `thinking` blocks with
+    an empty `thinking` field and a signature only (1939 blocks across 12
+    sessions, zero with text). Nothing here can recover it.
+  * Assistant text is sparse. Most agent turns are pure tool_use with no prose,
+    so a minority of LLM spans carry an output value.
+  * Non-conversation line types (mode, queue-operation, file-history-*,
+    attachment, ai-title, ...) are session bookkeeping and are dropped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+ATIF_SCHEMA_VERSION = "ATIF-v1.7"
+AGENT_NAME = "claude-code"
+
+#: Line types that carry conversation. Everything else is session bookkeeping.
+CONVERSATION_TYPES = frozenset({"user", "assistant", "system"})
+
+#: Cap on a single tool result stored in an observation, in characters.
+MAX_OBSERVATION_CHARS = 8000
+
+
+def _content_parts(message: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Normalize `message.content` to a list of part dicts."""
+    content = (message or {}).get("content")
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    return [p for p in (content or []) if isinstance(p, dict)]
+
+
+def _joined_text(parts: Iterable[dict[str, Any]], kind: str = "text") -> str:
+    """
+    Concatenate the text of all parts of `kind`.
+
+    NB: a `thinking` part stores its text under the ``thinking`` key, not
+    ``text``. Reading only ``text`` silently drops reasoning content.
+    """
+    out: list[str] = []
+    for part in parts:
+        if part.get("type") != kind:
+            continue
+        value = part.get(kind) if kind != "text" else None
+        out.append(value or part.get("text") or "")
+    return "\n".join(x for x in out if x)
+
+
+def session_to_atif(
+    lines: Iterable[dict[str, Any]],
+) -> tuple[dict[str, Any], Counter[str]]:
+    """
+    Convert parsed Claude Code session JSONL lines into an ATIF trajectory.
+
+    Args:
+        lines: Parsed JSONL objects, in file order (see
+            :meth:`ClaudeClient.read_session`).
+
+    Returns:
+        ``(trajectory, stats)`` where trajectory is a valid ATIF-v1.7 document
+        and stats counts what was mapped and what was dropped.
+    """
+    stats: Counter[str] = Counter()
+    steps: list[dict[str, Any]] = []
+    session_id: str | None = None
+    version: str | None = None
+    model: str | None = None
+
+    # Tool results arrive on later `user` lines; hold them until we can attach
+    # them to the agent step that issued the call.
+    pending_results: list[dict[str, Any]] = []
+    call_to_step: dict[str, int] = {}
+
+    for line in lines:
+        line_type = line.get("type")
+        stats[f"line:{line_type}"] += 1
+        session_id = session_id or line.get("sessionId") or line.get("session_id")
+        version = version or line.get("version")
+
+        if line_type not in CONVERSATION_TYPES:
+            stats["dropped_non_conversation"] += 1
+            continue
+
+        message = line.get("message") or {}
+        parts = _content_parts(message)
+        model = message.get("model") or model
+
+        tool_results = [p for p in parts if p.get("type") == "tool_result"]
+        if line_type == "user" and tool_results and not _joined_text(parts):
+            # Claude Code records tool RESULTS on user lines. These are not
+            # human turns; treating them as such invents turns that never
+            # happened (in one measured session, 112 of 154 user lines).
+            pending_results.extend(tool_results)
+            stats["tool_result_deferred"] += len(tool_results)
+            continue
+
+        _attach_results(steps, call_to_step, pending_results, stats)
+        pending_results = []
+
+        source = {"user": "user", "assistant": "agent", "system": "system"}[line_type]
+        step: dict[str, Any] = {
+            "step_id": len(steps) + 1,
+            "source": source,
+            "message": _joined_text(parts),
+        }
+        if line.get("timestamp"):
+            step["timestamp"] = line["timestamp"]
+
+        if source == "agent":
+            _enrich_agent_step(step, message, parts, call_to_step, len(steps), stats)
+
+        steps.append(step)
+        stats[f"step:{source}"] += 1
+
+    _attach_results(steps, call_to_step, pending_results, stats)
+
+    trajectory: dict[str, Any] = {
+        "schema_version": ATIF_SCHEMA_VERSION,
+        "session_id": session_id,
+        "trajectory_id": session_id,
+        "agent": {
+            "name": AGENT_NAME,
+            "version": version or "unknown",
+            **({"model_name": model} if model else {}),
+        },
+        "steps": steps,
+    }
+    logger.info(
+        "[atif] session=%s steps=%d tool_calls=%d dropped=%d",
+        session_id,
+        len(steps),
+        stats["tool_calls"],
+        stats["dropped_non_conversation"],
+    )
+    return trajectory, stats
+
+
+def _enrich_agent_step(
+    step: dict[str, Any],
+    message: dict[str, Any],
+    parts: list[dict[str, Any]],
+    call_to_step: dict[str, int],
+    step_index: int,
+    stats: Counter[str],
+) -> None:
+    """Attach reasoning, model, tool calls and token metrics to an agent step."""
+    reasoning = _joined_text(parts, "thinking")
+    if reasoning:
+        step["reasoning_content"] = reasoning
+        stats["reasoning_preserved"] += 1
+
+    if message.get("model"):
+        step["model_name"] = message["model"]
+
+    calls: list[dict[str, Any]] = []
+    for part in parts:
+        if part.get("type") != "tool_use":
+            continue
+        call_id = part.get("id") or f"call_{len(calls)}"
+        calls.append(
+            {
+                "tool_call_id": call_id,
+                "function_name": part.get("name") or "unknown",
+                "arguments": part.get("input") or {},
+            }
+        )
+        call_to_step[call_id] = step_index
+        stats["tool_calls"] += 1
+    if calls:
+        step["tool_calls"] = calls
+
+    usage = message.get("usage") or {}
+    if usage:
+        step["metrics"] = {
+            "prompt_tokens": usage.get("input_tokens"),
+            "completion_tokens": usage.get("output_tokens"),
+            "cached_tokens": usage.get("cache_read_input_tokens"),
+        }
+        stats["metrics_preserved"] += 1
+
+
+def _attach_results(
+    steps: list[dict[str, Any]],
+    call_to_step: dict[str, int],
+    results: list[dict[str, Any]],
+    stats: Counter[str],
+) -> None:
+    """
+    Attach deferred tool results as ATIF observations.
+
+    ATIF ObservationSchema is ``{"results": [{source_call_id, content}]}`` -- a
+    keyed array, NOT a flat ``{"content": ...}``. harbor-atif2otel builds its
+    observation map from ``results[].source_call_id``, so the flat shape is
+    silently ignored: the document still validates, the push still returns 200,
+    and every TOOL span lands with an empty output.
+    """
+    for result in results:
+        call_id = result.get("tool_use_id")
+        index = call_to_step.get(call_id)
+        target = steps[index] if index is not None else (steps[-1] if steps else None)
+        if target is None:
+            stats["orphan_tool_result"] += 1
+            continue
+        body = result.get("content")
+        if not isinstance(body, str):
+            body = json.dumps(body)
+        observation = target.setdefault("observation", {"results": []})
+        observation["results"].append(
+            {
+                **({"source_call_id": call_id} if call_id else {}),
+                "content": body[:MAX_OBSERVATION_CHARS],
+            }
+        )
+        stats["tool_result_attached"] += 1
+
+
+def session_file_to_atif(path: str | Path) -> tuple[dict[str, Any], Counter[str]]:
+    """Convert a session JSONL file on disk to an ATIF trajectory."""
+    path = Path(path)
+
+    def _lines() -> Iterable[dict[str, Any]]:
+        with path.open(errors="replace") as handle:
+            for raw in handle:
+                try:
+                    yield json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.debug("[atif] skipping unparseable line in %s", path)
+
+    return session_to_atif(_lines())

--- a/dev_agent_lens/export/atif.py
+++ b/dev_agent_lens/export/atif.py
@@ -250,3 +250,125 @@ def session_file_to_atif(path: str | Path) -> tuple[dict[str, Any], Counter[str]
                     logger.debug("[atif] skipping unparseable line in %s", path)
 
     return session_to_atif(_lines())
+
+
+#: Prefix Claude Code gives a subagent's own transcript file.
+SUBAGENT_FILE_PREFIX = "agent-"
+
+
+def _task_call_map(path: Path) -> dict[str, str]:
+    """
+    Map ``agentId`` -> the Task ``tool_use_id`` that spawned it.
+
+    A subagent's transcript lands in a sibling ``agent-<agentId>.jsonl``. The
+    only thing tying it back to the parent is the ``toolUseResult.agentId`` on
+    the parent's Task result line, whose ``tool_result`` block carries the
+    originating call id.
+    """
+    calls: dict[str, str] = {}
+    with path.open(errors="replace") as handle:
+        for raw in handle:
+            try:
+                line = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            result = line.get("toolUseResult")
+            if not isinstance(result, dict) or not result.get("agentId"):
+                continue
+            content = (line.get("message") or {}).get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "tool_result":
+                    calls[result["agentId"]] = part.get("tool_use_id")
+                    break
+    return calls
+
+
+def _attach_subagent_ref(trajectory: dict[str, Any], call_id: str, trajectory_id: str) -> bool:
+    """Point the observation for ``call_id`` at an embedded subagent trajectory."""
+    for step in trajectory.get("steps", []):
+        for result in (step.get("observation") or {}).get("results", []):
+            if result.get("source_call_id") == call_id:
+                result.setdefault("subagent_trajectory_ref", []).append(
+                    {"trajectory_id": trajectory_id}
+                )
+                return True
+    return False
+
+
+def session_tree_to_atif(
+    directory: str | Path,
+) -> tuple[list[dict[str, Any]], Counter[str]]:
+    """
+    Convert a directory of Claude Code session JSONL files to ATIF trajectories.
+
+    One trajectory per real session, with each ``agent-<agentId>.jsonl``
+    sidechain embedded in ``subagent_trajectories`` and referenced from the Task
+    observation that spawned it, so harbor-atif2otel nests the subagent spans
+    under their Task span.
+
+    Converting each file standalone instead is a trap worth naming: every
+    sidechain records the PARENT's ``sessionId``, and harbor-atif2otel seeds
+    trace ids from ``session_id`` and span ids from
+    ``{trace_id}:{trajectory_id}``. A directory of 57 files would collapse onto
+    2 trace ids with identical span seeds, and the collisions would silently
+    drop most of the spans. Giving every subagent a distinct ``trajectory_id``
+    is what keeps them apart.
+
+    Returns:
+        ``(trajectories, stats)``.
+    """
+    directory = Path(directory)
+    stats: Counter[str] = Counter()
+
+    files = sorted(directory.rglob("*.jsonl"))
+    subagents = {
+        f.name[len(SUBAGENT_FILE_PREFIX) : -len(".jsonl")]: f
+        for f in files
+        if f.name.startswith(SUBAGENT_FILE_PREFIX)
+    }
+    mains = [f for f in files if not f.name.startswith(SUBAGENT_FILE_PREFIX)]
+    logger.info(
+        "[atif] tree=%s sessions=%d subagent_files=%d",
+        directory, len(mains), len(subagents),
+    )
+
+    trajectories: list[dict[str, Any]] = []
+    for main in mains:
+        trajectory, session_stats = session_file_to_atif(main)
+        stats.update(session_stats)
+
+        embedded: list[dict[str, Any]] = []
+        for agent_id, call_id in _task_call_map(main).items():
+            sub_file = subagents.get(agent_id)
+            if sub_file is None:
+                # Task ran outside the exported window; its transcript is absent.
+                stats["subagent_transcript_missing"] += 1
+                continue
+            sub, _ = session_file_to_atif(sub_file)
+            trajectory_id = f"{SUBAGENT_FILE_PREFIX}{agent_id}"
+            # session_id stays the parent's (ATIF v1.7 allows sharing it);
+            # trajectory_id is what must be unique.
+            sub["trajectory_id"] = trajectory_id
+            embedded.append(sub)
+            if _attach_subagent_ref(trajectory, call_id, trajectory_id):
+                stats["subagent_linked"] += 1
+            else:
+                stats["subagent_unlinked"] += 1
+                logger.warning(
+                    "[atif] no observation for call_id=%s (agent=%s)", call_id, agent_id
+                )
+        if embedded:
+            trajectory["subagent_trajectories"] = embedded
+
+        logger.info(
+            "[atif] session=%s steps=%d subagents=%d",
+            trajectory.get("session_id"),
+            len(trajectory["steps"]),
+            len(embedded),
+        )
+        trajectories.append(trajectory)
+        stats["sessions"] += 1
+
+    return trajectories, stats

--- a/dev_agent_lens/export/otlp.py
+++ b/dev_agent_lens/export/otlp.py
@@ -1,0 +1,291 @@
+"""
+Push ATIF trajectories to an OTLP backend (Phoenix).
+
+`harbor-atif2otel` turns an ATIF trajectory into OTel spans; this module gets
+those spans into Phoenix without losing any, which takes more care than it
+sounds like.
+
+Two failure modes, both silent, both measured on a real 10,348-span backfill:
+
+  * **A span whose ``end_time`` precedes its ``start_time`` kills the whole
+    insert batch.** harbor-atif2otel closes a ``turn-N`` span on the last step
+    of the turn, and a later step can carry an earlier timestamp than the one
+    that opened it. 9 such spans were enough for Phoenix to answer ``200 OK``
+    twice and persist 98 of 10,348, with nothing in its log. :func:`clamp_times`
+    is not cosmetic.
+  * **The ingest queue is bounded.** Phoenix enqueues and returns before it
+    writes, so the response code says nothing about persistence. Once the
+    timestamps were valid it started answering ``503 Server is at capacity``
+    instead: the queue drains only as fast as the backing Postgres accepts, and
+    a single 29 MB request never had a chance. Hence small chunks and backoff.
+
+So: **never treat a 200 as proof.** Verify by counting rows in the backing
+store afterwards.
+
+Re-running a push is safe. Trace ids are seeded from ``session_id`` and span ids
+from step index, both deterministic, so Phoenix's insert dedup makes spans that
+already landed no-ops.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+#: Phoenix reads its project name off this resource attribute.
+PROJECT_ATTRIBUTE = "openinference.project.name"
+
+#: OpenInference's user attribution attribute.
+USER_ATTRIBUTE = "user.id"
+
+DEFAULT_CHUNK_SIZE = 100
+DEFAULT_PAUSE_SECONDS = 1.0
+DEFAULT_MAX_RETRIES = 12
+MAX_BACKOFF_SECONDS = 30.0
+BACKOFF_FACTOR = 1.7
+
+
+@dataclass
+class PushResult:
+    """Outcome of a push. `spans_sent` counts spans Phoenix ACCEPTED, not stored."""
+
+    spans_total: int = 0
+    spans_sent: int = 0
+    requests: int = 0
+    retries_503: int = 0
+    failed_chunks: int = 0
+    exhausted_chunks: int = 0
+    clamped_spans: int = 0
+    stats: Counter = field(default_factory=Counter)
+
+    @property
+    def complete(self) -> bool:
+        return (
+            self.spans_sent == self.spans_total
+            and not self.failed_chunks
+            and not self.exhausted_chunks
+        )
+
+
+def _import_otel():
+    """Import the optional OTel/harbor stack, with an actionable error."""
+    try:
+        from harbor_atif2otel import convert_trajectory
+        from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+            ExportTraceServiceRequest,
+        )
+        from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+        from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans
+    except ImportError as exc:  # pragma: no cover - depends on optional extras
+        raise ImportError(
+            "OTLP export needs harbor-atif2otel and opentelemetry-proto. "
+            "Install with: uv pip install 'dev_agent_lens[otlp]'"
+        ) from exc
+    return (
+        convert_trajectory,
+        ExportTraceServiceRequest,
+        AnyValue,
+        KeyValue,
+        ResourceSpans,
+        ScopeSpans,
+    )
+
+
+def clamp_times(spans: Iterable[Any]) -> int:
+    """
+    Force ``end_time >= start_time`` on every span, returning how many moved.
+
+    Phoenix rejects an entire insert batch on a negative duration and reports
+    neither an error code nor a log line, so one bad span silently costs
+    thousands of good ones.
+    """
+    clamped = 0
+    for span in spans:
+        if span.end_time_unix_nano < span.start_time_unix_nano:
+            span.end_time_unix_nano = span.start_time_unix_nano
+            clamped += 1
+    return clamped
+
+
+def build_spans(
+    trajectories: list[dict[str, Any]],
+    project: str,
+    user_id: str | None = None,
+    service_name: str = "claude-code",
+) -> tuple[Any, list[tuple[Any, Any]], int]:
+    """
+    Convert trajectories to OTel spans, tagged and clamped.
+
+    Returns:
+        ``(resource, spans, clamped)`` where `resource` carries the project
+        routing attribute and `spans` is a list of ``(scope, span)`` pairs.
+    """
+    convert_trajectory, _, AnyValue, KeyValue, ResourceSpans, _ = _import_otel()
+
+    def kv(key: str, value: str):
+        return KeyValue(key=key, value=AnyValue(string_value=value))
+
+    resource = None
+    spans: list[tuple[Any, Any]] = []
+    for trajectory in trajectories:
+        started = time.perf_counter()
+        resource_spans = convert_trajectory(trajectory, service_name=service_name)
+        if resource is None:
+            resource = ResourceSpans()
+            resource.resource.CopyFrom(resource_spans.resource)
+            resource.resource.attributes.append(kv(PROJECT_ATTRIBUTE, project))
+        before = len(spans)
+        for scope_span in resource_spans.scope_spans:
+            for span in scope_span.spans:
+                if user_id:
+                    # harbor-atif2otel builds a fixed root attribute list with no
+                    # passthrough for ATIF's root `extra`, so attribution is
+                    # stamped here. Moving it upstream is the durable fix.
+                    span.attributes.append(kv(USER_ATTRIBUTE, user_id))
+                spans.append((scope_span.scope, span))
+        logger.info(
+            "[otlp] converted session=%s spans=%d in %.0fms",
+            trajectory.get("session_id"),
+            len(spans) - before,
+            (time.perf_counter() - started) * 1000,
+        )
+
+    clamped = clamp_times(span for _, span in spans)
+    if clamped:
+        logger.warning("[otlp] clamped %d spans whose end preceded their start", clamped)
+    return resource, spans, clamped
+
+
+def push_trajectories(
+    endpoint: str,
+    trajectories: list[dict[str, Any]],
+    project: str,
+    user_id: str | None = None,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    pause: float = DEFAULT_PAUSE_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    service_name: str = "claude-code",
+    dry_run: bool = False,
+) -> PushResult:
+    """
+    Convert and push trajectories to an OTLP HTTP endpoint in small chunks.
+
+    Args:
+        endpoint: Base URL, e.g. ``http://127.0.0.1:6006``. ``/v1/traces`` is
+            appended.
+        dry_run: Convert and validate, send nothing.
+
+    A completed push means every chunk was ACCEPTED. Confirm persistence by
+    counting rows in the backing store; see the module docstring.
+    """
+    _, ExportTraceServiceRequest, _, _, ResourceSpans, ScopeSpans = _import_otel()
+
+    resource, spans, clamped = build_spans(trajectories, project, user_id, service_name)
+    result = PushResult(spans_total=len(spans), clamped_spans=clamped)
+    if not spans:
+        logger.warning("[otlp] nothing to push")
+        return result
+
+    duplicates = _count_duplicate_ids(spans)
+    result.stats["duplicate_span_ids"] = duplicates
+    if duplicates:
+        raise ValueError(
+            f"{duplicates} spans share a (trace_id, span_id); the backend would drop "
+            "them. Give every subagent trajectory a distinct trajectory_id."
+        )
+
+    if dry_run:
+        logger.info("[otlp] dry run: %d spans ready, nothing sent", len(spans))
+        return result
+
+    url = endpoint.rstrip("/") + "/v1/traces"
+    for start in range(0, len(spans), chunk_size):
+        batch = spans[start : start + chunk_size]
+        payload = ResourceSpans()
+        payload.resource.CopyFrom(resource.resource)
+        scope_spans = ScopeSpans()
+        scope_spans.scope.CopyFrom(batch[0][0])
+        scope_spans.spans.extend(span for _, span in batch)
+        payload.scope_spans.append(scope_spans)
+        body = ExportTraceServiceRequest(resource_spans=[payload]).SerializeToString()
+
+        _push_chunk(url, body, batch, start, len(spans), pause, max_retries, result)
+        time.sleep(pause)
+
+    logger.info(
+        "[otlp] done accepted=%d/%d requests=%d retries_503=%d failed=%d",
+        result.spans_sent,
+        result.spans_total,
+        result.requests,
+        result.retries_503,
+        result.failed_chunks + result.exhausted_chunks,
+    )
+    return result
+
+
+def _push_chunk(
+    url: str,
+    body: bytes,
+    batch: list[tuple[Any, Any]],
+    start: int,
+    total: int,
+    pause: float,
+    max_retries: int,
+    result: PushResult,
+) -> None:
+    delay = pause
+    for attempt in range(max_retries):
+        request = urllib.request.Request(
+            url, data=body, headers={"Content-Type": "application/x-protobuf"}
+        )
+        started = time.perf_counter()
+        try:
+            with urllib.request.urlopen(request, timeout=120) as response:
+                status = response.status
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+        except urllib.error.URLError as exc:
+            result.requests += 1
+            result.failed_chunks += 1
+            logger.error("[otlp] %d/%d transport error: %s", start + len(batch), total, exc.reason)
+            return
+        result.requests += 1
+        elapsed = (time.perf_counter() - started) * 1000
+
+        if status == 200:
+            result.spans_sent += len(batch)
+            logger.info(
+                "[otlp] %d/%d bytes=%d in %.0fms retries=%d",
+                start + len(batch), total, len(body), elapsed, attempt,
+            )
+            return
+        if status == 503:
+            # Bounded ingest queue. Wait for it to drain rather than lose spans.
+            result.retries_503 += 1
+            delay = min(delay * BACKOFF_FACTOR, MAX_BACKOFF_SECONDS)
+            logger.info(
+                "[otlp] %d/%d at capacity, waiting %.1fs", start + len(batch), total, delay
+            )
+            time.sleep(delay)
+            continue
+        result.failed_chunks += 1
+        logger.error("[otlp] %d/%d -> HTTP %s", start + len(batch), total, status)
+        return
+
+    result.exhausted_chunks += 1
+    logger.error("[otlp] %d/%d gave up after %d retries", start + len(batch), total, max_retries)
+
+
+def _count_duplicate_ids(spans: list[tuple[Any, Any]]) -> int:
+    """Count spans sharing a (trace_id, span_id); the backend keeps only one."""
+    seen: Counter = Counter()
+    for _, span in spans:
+        seen[(bytes(span.trace_id), bytes(span.span_id))] += 1
+    return sum(count - 1 for count in seen.values() if count > 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,14 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
 ]
+# `dal push-atif` only. Kept optional so the core CLI has no OTel dependency.
+# harbor-atif2otel needs 3.12+ while this package supports 3.11, so it is
+# marker-gated; on 3.11 the import fails with an actionable message instead of
+# making the whole extra unresolvable.
+otlp = [
+    "harbor-atif2otel>=0.1.0; python_version >= '3.12'",
+    "opentelemetry-proto>=1.20.0",
+]
 
 [project.scripts]
 dal = "dev_agent_lens.cli.main:main"

--- a/tests/export/test_atif.py
+++ b/tests/export/test_atif.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for the Claude Code session -> ATIF exporter.
+
+The two behaviours worth pinning down both failed silently in practice:
+
+  * Tool results ride on `user` lines. Treating them as human turns invents
+    turns that never happened (112 of 154 user lines in a measured session).
+  * ATIF observations must be `{"results": [{source_call_id, content}]}`. Emit a
+    flat `{"content": ...}` and the document still validates, the OTLP push
+    still returns 200, and every TOOL span lands with an empty output.
+"""
+
+from dev_agent_lens.export.atif import (
+    ATIF_SCHEMA_VERSION,
+    session_to_atif,
+)
+
+
+def _assistant(text=None, tool_use=None, thinking=None, usage=None, ts="2026-08-04T10:00:00Z"):
+    content = []
+    if thinking is not None:
+        content.append({"type": "thinking", "thinking": thinking, "signature": "sig"})
+    if text:
+        content.append({"type": "text", "text": text})
+    for call_id, name, args in tool_use or []:
+        content.append({"type": "tool_use", "id": call_id, "name": name, "input": args})
+    message = {"role": "assistant", "content": content, "model": "claude-opus-5"}
+    if usage:
+        message["usage"] = usage
+    return {"type": "assistant", "timestamp": ts, "sessionId": "s1",
+            "version": "2.1.0", "message": message}
+
+
+def _user_text(text, ts="2026-08-04T09:59:00Z"):
+    return {"type": "user", "timestamp": ts, "sessionId": "s1",
+            "message": {"role": "user", "content": text}}
+
+
+def _tool_result(call_id, content, ts="2026-08-04T10:00:05Z"):
+    return {"type": "user", "timestamp": ts, "sessionId": "s1",
+            "message": {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": call_id, "content": content}]}}
+
+
+def test_produces_valid_atif_envelope():
+    traj, _ = session_to_atif([_user_text("hi"), _assistant(text="hello")])
+    assert traj["schema_version"] == ATIF_SCHEMA_VERSION
+    assert traj["agent"]["name"] == "claude-code"
+    assert traj["agent"]["version"] == "2.1.0"
+    assert traj["session_id"] == "s1"
+    assert [s["source"] for s in traj["steps"]] == ["user", "agent"]
+    assert all("step_id" in s and "message" in s for s in traj["steps"])
+
+
+def test_tool_results_are_not_counted_as_user_turns():
+    lines = [
+        _user_text("run ls"),
+        _assistant(tool_use=[("call_1", "Bash", {"command": "ls"})]),
+        _tool_result("call_1", "file_a\nfile_b"),
+    ]
+    traj, stats = session_to_atif(lines)
+
+    sources = [s["source"] for s in traj["steps"]]
+    assert sources == ["user", "agent"], "the tool result must not become a user turn"
+    assert stats["step:user"] == 1
+    assert stats["tool_result_attached"] == 1
+
+
+def test_observation_uses_keyed_results_array():
+    lines = [
+        _assistant(tool_use=[("call_1", "Bash", {"command": "ls"})]),
+        _tool_result("call_1", "file_a"),
+    ]
+    traj, _ = session_to_atif(lines)
+
+    observation = traj["steps"][0]["observation"]
+    # Shape matters: harbor-atif2otel keys its observation map on
+    # results[].source_call_id. A flat {"content": ...} is silently dropped.
+    assert set(observation) == {"results"}
+    assert observation["results"] == [
+        {"source_call_id": "call_1", "content": "file_a"}
+    ]
+
+
+def test_result_attaches_to_the_step_that_issued_the_call():
+    lines = [
+        _assistant(tool_use=[("call_a", "Read", {})]),
+        _assistant(tool_use=[("call_b", "Bash", {})]),
+        _tool_result("call_a", "from A"),
+        _tool_result("call_b", "from B"),
+    ]
+    traj, _ = session_to_atif(lines)
+
+    first, second = traj["steps"][0], traj["steps"][1]
+    assert first["observation"]["results"][0]["content"] == "from A"
+    assert second["observation"]["results"][0]["content"] == "from B"
+
+
+def test_tool_calls_and_metrics_are_preserved():
+    lines = [_assistant(
+        tool_use=[("call_1", "Bash", {"command": "ls"})],
+        usage={"input_tokens": 10, "output_tokens": 5, "cache_read_input_tokens": 100},
+    )]
+    traj, _ = session_to_atif(lines)
+
+    step = traj["steps"][0]
+    assert step["tool_calls"] == [
+        {"tool_call_id": "call_1", "function_name": "Bash", "arguments": {"command": "ls"}}
+    ]
+    assert step["metrics"] == {
+        "prompt_tokens": 10, "completion_tokens": 5, "cached_tokens": 100
+    }
+    assert step["model_name"] == "claude-opus-5"
+
+
+def test_thinking_text_is_read_from_the_thinking_key():
+    # A thinking part stores text under "thinking", not "text".
+    traj, stats = session_to_atif([_assistant(thinking="deliberating", text="done")])
+    assert traj["steps"][0]["reasoning_content"] == "deliberating"
+    assert stats["reasoning_preserved"] == 1
+
+
+def test_empty_thinking_blocks_yield_no_reasoning():
+    # Claude Code writes signature-only thinking blocks in practice.
+    traj, stats = session_to_atif([_assistant(thinking="", text="done")])
+    assert "reasoning_content" not in traj["steps"][0]
+    assert stats["reasoning_preserved"] == 0
+
+
+def test_bookkeeping_lines_are_dropped():
+    lines = [
+        {"type": "queue-operation", "sessionId": "s1"},
+        {"type": "file-history-snapshot", "sessionId": "s1"},
+        {"type": "ai-title", "sessionId": "s1"},
+        _user_text("real turn"),
+    ]
+    traj, stats = session_to_atif(lines)
+    assert len(traj["steps"]) == 1
+    assert stats["dropped_non_conversation"] == 3
+
+
+def test_step_ids_are_sequential_from_one():
+    traj, _ = session_to_atif([_user_text("a"), _assistant(text="b"), _user_text("c")])
+    assert [s["step_id"] for s in traj["steps"]] == [1, 2, 3]

--- a/tests/export/test_atif_subagents.py
+++ b/tests/export/test_atif_subagents.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for embedding subagent sidechains into a parent ATIF trajectory.
+
+The behaviour worth pinning down: every `agent-<agentId>.jsonl` records the
+PARENT's sessionId, and harbor-atif2otel seeds trace ids from `session_id` and
+span ids from `{trace_id}:{trajectory_id}`. If the subagents don't each get a
+distinct `trajectory_id`, a directory of sidechains collapses onto one trace
+with identical span seeds and the backend drops the collisions silently.
+"""
+
+import json
+
+from dev_agent_lens.export.atif import session_tree_to_atif
+
+SESSION_ID = "11111111-2222-3333-4444-555555555555"
+AGENT_ID = "a0123456789abcdef"
+
+
+def _line(**fields):
+    return {"sessionId": SESSION_ID, "version": "2.1.0", **fields}
+
+
+def _parent_lines(agent_id=AGENT_ID, call_id="call-1"):
+    return [
+        _line(
+            type="user",
+            timestamp="2026-08-10T10:00:00Z",
+            message={"role": "user", "content": "delegate this"},
+        ),
+        _line(
+            type="assistant",
+            timestamp="2026-08-10T10:00:01Z",
+            message={
+                "role": "assistant",
+                "model": "claude-opus-5",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": call_id,
+                        "name": "Task",
+                        "input": {"prompt": "go"},
+                    }
+                ],
+            },
+        ),
+        _line(
+            type="user",
+            timestamp="2026-08-10T10:00:30Z",
+            message={
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": call_id, "content": "done"}
+                ],
+            },
+            toolUseResult={"agentId": agent_id, "content": [{"type": "text", "text": "done"}]},
+        ),
+    ]
+
+
+def _subagent_lines():
+    return [
+        _line(
+            type="user",
+            isSidechain=True,
+            timestamp="2026-08-10T10:00:02Z",
+            message={"role": "user", "content": "go"},
+        ),
+        _line(
+            type="assistant",
+            isSidechain=True,
+            timestamp="2026-08-10T10:00:03Z",
+            message={
+                "role": "assistant",
+                "model": "claude-opus-5",
+                "content": [{"type": "text", "text": "done"}],
+                "usage": {"input_tokens": 10, "output_tokens": 2},
+            },
+        ),
+    ]
+
+
+def _write(directory, name, lines):
+    path = directory / name
+    path.write_text("\n".join(json.dumps(line) for line in lines))
+    return path
+
+
+def test_subagent_is_embedded_and_referenced(tmp_path):
+    _write(tmp_path, f"{SESSION_ID}.jsonl", _parent_lines())
+    _write(tmp_path, f"agent-{AGENT_ID}.jsonl", _subagent_lines())
+
+    trajectories, stats = session_tree_to_atif(tmp_path)
+
+    assert len(trajectories) == 1, "a sidechain file is not a session of its own"
+    parent = trajectories[0]
+    assert stats["subagent_linked"] == 1
+
+    embedded = parent["subagent_trajectories"]
+    assert len(embedded) == 1
+    assert embedded[0]["trajectory_id"] == f"agent-{AGENT_ID}"
+
+    refs = [
+        ref
+        for step in parent["steps"]
+        for result in (step.get("observation") or {}).get("results", [])
+        for ref in result.get("subagent_trajectory_ref", [])
+    ]
+    assert refs == [{"trajectory_id": f"agent-{AGENT_ID}"}]
+
+
+def test_subagent_trajectory_id_is_distinct_from_the_parent(tmp_path):
+    """Sharing session_id is fine; sharing trajectory_id collides span seeds."""
+    _write(tmp_path, f"{SESSION_ID}.jsonl", _parent_lines())
+    _write(tmp_path, f"agent-{AGENT_ID}.jsonl", _subagent_lines())
+
+    parent = session_tree_to_atif(tmp_path)[0][0]
+    child = parent["subagent_trajectories"][0]
+
+    assert child["session_id"] == parent["session_id"]
+    assert child["trajectory_id"] != parent["trajectory_id"]
+
+
+def test_task_call_without_a_transcript_is_counted_not_dropped_silently(tmp_path):
+    _write(tmp_path, f"{SESSION_ID}.jsonl", _parent_lines())  # no agent-*.jsonl
+
+    trajectories, stats = session_tree_to_atif(tmp_path)
+
+    assert stats["subagent_transcript_missing"] == 1
+    assert "subagent_trajectories" not in trajectories[0]
+
+
+def test_multiple_subagents_get_distinct_trajectory_ids(tmp_path):
+    lines = _parent_lines(agent_id="a1", call_id="call-1")
+    lines += _parent_lines(agent_id="a2", call_id="call-2")[1:]
+    _write(tmp_path, f"{SESSION_ID}.jsonl", lines)
+    _write(tmp_path, "agent-a1.jsonl", _subagent_lines())
+    _write(tmp_path, "agent-a2.jsonl", _subagent_lines())
+
+    parent, stats = session_tree_to_atif(tmp_path)
+    embedded = parent[0]["subagent_trajectories"]
+
+    assert stats["subagent_linked"] == 2
+    assert {t["trajectory_id"] for t in embedded} == {"agent-a1", "agent-a2"}

--- a/tests/export/test_otlp.py
+++ b/tests/export/test_otlp.py
@@ -1,0 +1,130 @@
+"""
+Unit tests for the OTLP push.
+
+Both behaviours under test cost a real backfill. A span whose end precedes its
+start makes the backend reject the whole insert batch while still answering
+200, and its ingest queue is bounded, so a full queue answers 503 and the spans
+are lost unless the push waits and retries.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from dev_agent_lens.export import otlp
+
+
+class _Span:
+    """Minimal stand-in for the OTel protobuf span fields we touch."""
+
+    def __init__(self, start, end, trace_id=b"t", span_id=b"s"):
+        self.start_time_unix_nano = start
+        self.end_time_unix_nano = end
+        self.trace_id = trace_id
+        self.span_id = span_id
+
+
+def test_clamp_times_fixes_only_negative_durations():
+    spans = [_Span(100, 50), _Span(100, 100), _Span(100, 200)]
+
+    clamped = otlp.clamp_times(spans)
+
+    assert clamped == 1
+    assert [s.end_time_unix_nano for s in spans] == [100, 100, 200]
+
+
+def test_duplicate_span_ids_are_detected():
+    spans = [
+        (None, _Span(1, 2, b"trace", b"a")),
+        (None, _Span(1, 2, b"trace", b"a")),
+        (None, _Span(1, 2, b"trace", b"b")),
+    ]
+
+    assert otlp._count_duplicate_ids(spans) == 1
+
+
+def test_no_duplicates_across_different_traces():
+    spans = [
+        (None, _Span(1, 2, b"trace-1", b"a")),
+        (None, _Span(1, 2, b"trace-2", b"a")),
+    ]
+
+    assert otlp._count_duplicate_ids(spans) == 0
+
+
+def _push_chunk(statuses, max_retries=5, pause=0.0):
+    """Drive _push_chunk against a scripted sequence of HTTP statuses."""
+    result = otlp.PushResult(spans_total=1)
+    calls = iter(statuses)
+
+    def fake_urlopen(request, timeout=None):
+        status = next(calls)
+        if status >= 400:
+            import urllib.error
+
+            raise urllib.error.HTTPError(request.full_url, status, "", None, None)
+
+        class _Response:
+            def __enter__(self_inner):
+                return SimpleNamespace(status=status)
+
+            def __exit__(self_inner, *exc):
+                return False
+
+        return _Response()
+
+    with patch.object(otlp.urllib.request, "urlopen", fake_urlopen):
+        otlp._push_chunk(
+            "http://x/v1/traces", b"body", [(None, None)], 0, 1, pause, max_retries, result
+        )
+    return result
+
+
+def test_503_is_retried_until_the_queue_drains():
+    result = _push_chunk([503, 503, 200])
+
+    assert result.spans_sent == 1
+    assert result.retries_503 == 2
+    assert result.requests == 3
+    assert result.complete
+
+
+def test_persistent_503_gives_up_and_is_reported_not_swallowed():
+    result = _push_chunk([503] * 10, max_retries=3)
+
+    assert result.spans_sent == 0
+    assert result.exhausted_chunks == 1
+    assert not result.complete
+
+
+def test_other_http_errors_fail_the_chunk_immediately():
+    result = _push_chunk([500, 200])
+
+    assert result.spans_sent == 0
+    assert result.failed_chunks == 1
+    assert result.requests == 1, "a 500 is not retried"
+
+
+def test_push_refuses_to_send_colliding_span_ids():
+    spans = [(None, _Span(1, 2, b"trace", b"a")), (None, _Span(1, 2, b"trace", b"a"))]
+
+    with patch.object(otlp, "_import_otel", return_value=(None,) * 6), patch.object(
+        otlp, "build_spans", return_value=(object(), spans, 0)
+    ):
+        with pytest.raises(ValueError, match="trace_id, span_id"):
+            otlp.push_trajectories("http://x", [{}], project="p")
+
+
+def test_dry_run_sends_nothing():
+    spans = [(None, _Span(1, 2, b"trace", b"a"))]
+
+    with patch.object(otlp, "_import_otel", return_value=(None,) * 6), patch.object(
+        otlp, "build_spans", return_value=(object(), spans, 3)
+    ), patch.object(otlp.urllib.request, "urlopen") as urlopen:
+        result = otlp.push_trajectories("http://x", [{}], project="p", dry_run=True)
+
+    urlopen.assert_not_called()
+    assert result.spans_total == 1
+    assert result.clamped_spans == 3
+    assert result.spans_sent == 0

--- a/uv.lock
+++ b/uv.lock
@@ -4,10 +4,12 @@ requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version < '3.12' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
-    "python_full_version >= '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -115,10 +117,14 @@ dependencies = [
     { name = "numpy" },
     { name = "openinference-instrumentation" },
     { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-exporter-otlp", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-exporter-otlp", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-proto", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-proto", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.60b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.65b0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "orjson" },
     { name = "pandas" },
     { name = "prometheus-client" },
@@ -152,8 +158,10 @@ dependencies = [
     { name = "httpx" },
     { name = "openinference-instrumentation" },
     { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-exporter-otlp", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-exporter-otlp", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
@@ -170,7 +178,8 @@ dependencies = [
     { name = "jsonpath-ng" },
     { name = "openinference-instrumentation" },
     { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-api", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pandas" },
     { name = "pydantic" },
     { name = "pystache" },
@@ -189,10 +198,14 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openinference-instrumentation" },
     { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-exporter-otlp", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-exporter-otlp", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-proto", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-proto", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.60b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.65b0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "typing-extensions" },
     { name = "wrapt" },
 ]
@@ -573,6 +586,11 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+otlp = [
+    { name = "harbor-atif2otel", marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-proto", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-proto", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -580,7 +598,9 @@ requires-dist = [
     { name = "arize-phoenix", specifier = ">=4.0.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "duckdb", specifier = ">=1.4.3,<1.6" },
+    { name = "harbor-atif2otel", marker = "python_full_version >= '3.12' and extra == 'otlp'", specifier = ">=0.1.0" },
     { name = "openai", specifier = ">=2.13.0" },
+    { name = "opentelemetry-proto", marker = "extra == 'otlp'", specifier = ">=1.20.0" },
     { name = "oxenai", specifier = ">=0.42.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
@@ -591,7 +611,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "otlp"]
 
 [[package]]
 name = "distro"
@@ -825,6 +845,18 @@ wheels = [
 ]
 
 [[package]]
+name = "harbor-atif2otel"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/4e/434f0f1f249716f6e70c6c719ad91c14514b500412b11021b59fd168c1d4/harbor_atif2otel-0.1.1.tar.gz", hash = "sha256:439769f9dcd0787ecb1a25fe3ebe18e6be4a204f0f903dc157cc7fd166be51ce", size = 41572, upload-time = "2026-08-22T03:38:49.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fd/1ed9dc788d3c00d07e9d0b457ba19e3d577d8896ac0cb73a0dcce2365383/harbor_atif2otel-0.1.1-py3-none-any.whl", hash = "sha256:bd04effeab5e31c12ef86b5dbd4481b97e509ee2dfb41e557d7d1cc4e139d4a3", size = 22597, upload-time = "2026-08-22T03:38:48.585Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -866,7 +898,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1201,8 +1233,10 @@ version = "0.1.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-api", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/d0/b19061a21fd6127d2857c77744a36073bba9c1502d1d5e8517b708eb8b7c/openinference_instrumentation-0.1.42.tar.gz", hash = "sha256:2275babc34022e151b5492cfba41d3b12e28377f8e08cb45e5d64fe2d9d7fe37", size = 23954, upload-time = "2025-11-05T01:37:46.869Z" }
@@ -1223,9 +1257,13 @@ wheels = [
 name = "opentelemetry-api"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
 wheels = [
@@ -1233,12 +1271,36 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-otlp"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/9c/3ab1db90f32da200dba332658f2bbe602369e3d19f6aba394031a42635be/opentelemetry_exporter_otlp-1.39.1.tar.gz", hash = "sha256:7cf7470e9fd0060c8a38a23e4f695ac686c06a48ad97f8d4867bc9b420180b9c", size = 6147, upload-time = "2025-12-11T13:32:40.309Z" }
 wheels = [
@@ -1246,11 +1308,36 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/45/7af37fe54e5d3e66e7dcd7ba8b8aeee73f202bfac909cc94b8c4e428f9ac/opentelemetry_exporter_otlp-1.44.0.tar.gz", hash = "sha256:af1cde7c33ea8ed624bf04ac49a885730fe44c1f1ad698656e592c38f70ce106", size = 6090, upload-time = "2026-07-16T15:25:34.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/c3/7b466a9463944e70b37b744072a0c1b88a425dade3fff0631adec66c9bcc/opentelemetry_exporter_otlp-1.44.0-py3-none-any.whl", hash = "sha256:4a498fa8d8fd8be9e8e2d175fe5524a3fe581ccffadd8509db86526a5fb97051", size = 6727, upload-time = "2026-07-16T15:25:14.445Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-proto", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
 wheels = [
@@ -1258,17 +1345,41 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "opentelemetry-proto", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "python_full_version < '3.12'" },
+    { name = "grpcio", marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-proto", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
 wheels = [
@@ -1276,17 +1387,47 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "googleapis-common-protos", marker = "python_full_version >= '3.12'" },
+    { name = "grpcio", marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-api", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-proto", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-proto", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "requests", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
 wheels = [
@@ -1294,11 +1435,41 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "googleapis-common-protos", marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-api", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-proto", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-sdk", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
 wheels = [
@@ -1306,13 +1477,37 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "protobuf", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
 name = "opentelemetry-sdk"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.60b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
 wheels = [
@@ -1320,16 +1515,63 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.65b0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Completes the session-JSONL backfill path: raw Claude Code transcripts in, spans in Phoenix out.

Validated by actually running it — a teammate's Aug 6–20 sessions, **10,348 spans**, confirmed by row count in Phoenix rather than by an HTTP status.

## What's here

**`session_to_atif` / `session_file_to_atif`** (first commit) — Claude Code session JSONL to an ATIF-v1.7 trajectory, the mapping layer `harbor-atif2otel` was missing.

**`session_tree_to_atif`** — converts a whole directory, nesting subagents. This one has a trap worth naming: every `agent-<agentId>.jsonl` sidechain records the **parent's** `sessionId`, and `harbor-atif2otel` seeds trace ids from `session_id` and span ids from `{trace_id}:{trajectory_id}`. Converting a directory file-by-file collapses it onto one trace id per session with identical span seeds, and the collisions are dropped silently. Each sidechain is now matched to its Task call via `toolUseResult.agentId`, embedded in `subagent_trajectories` with a distinct `trajectory_id`, and referenced from the Task observation — so subagent spans nest under the Task span that spawned them.

**`export/otlp.py`** — the push. Two silent failure modes, both measured on the backfill:

| | Symptom | Fix |
|---|---|---|
| `end_time < start_time` | Phoenix rejects the **entire insert batch**, answers `200 OK`, logs nothing. 9 bad spans cost 10,250 good ones. | clamp `end = max(end, start)` |
| Bounded ingest queue | A 29MB request is discarded; with valid timestamps it surfaces honestly as `503 Server is at capacity` | chunk (~100 spans) + exponential backoff |

The module reports "accepted", never "stored", and says so — a 200 from `/v1/traces` is not proof the spans landed.

## CLI

```bash
dal export-atif ~/.claude/projects/<encoded-repo> -o traj.json
dal push-atif traj.json --endpoint http://127.0.0.1:6006 \
    --project claude-code-sessions --user alice
```

Both are re-runnable. Trace and span ids are deterministic, so re-pushing spans that already landed is a no-op — a partial push is fixed by running it again.

## Notes for review

- **`user.id` is stamped at push time, not in the converter.** `harbor-atif2otel` builds a fixed root attribute list with no passthrough for ATIF's root `extra`. Adding that passthrough upstream is the durable fix; it's deliberately not in this PR.
- **The `otlp` extra is marker-gated.** `harbor-atif2otel` requires Python ≥3.12 while this package supports ≥3.11. Ungated, the extra is unresolvable on 3.11; gated, the import fails with an actionable message.
- No new core dependencies — the push uses stdlib `urllib`.

## Testing

- 12 new unit tests (subagent linkage and distinct trajectory ids; clamping, 503 backoff, give-up reporting, collision refusal, dry run). Repo suite: **1,022 passed**, unchanged at 18 pre-existing failures.
- E2E was the real backfill against Phoenix rather than `dal run testbed` — this change doesn't touch the capture pipeline the testbed exercises, and a verified 10,348-span push through the actual code path is the stronger evidence. Packaged CLI reproduces the ad-hoc run exactly: 2 trajectories, 3,033 steps, 56 subagents linked, 10,348 spans, 9 clamped.

https://claude.ai/code/session_015zeEyfiYURD9wV1HprgtLm
