### PR TITLE
security: scrub live OAuth token from examples/.env.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .env
 
+# Agent worktrees. These hold their own filled-in .env.example copies, which
+# .env alone does not cover.
+.conductor/
+
 # Node.js dependencies
 node_modules/
 examples/typescript/node_modules/

--- a/examples/python/.env.example
+++ b/examples/python/.env.example
@@ -6,7 +6,7 @@
 # ANTHROPIC_BASE_URL=http://localhost:8082
 
 # Option 2: OAuth Authentication (basic_usage_oauth.py) 
-ANTHROPIC_AUTH_TOKEN=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
+ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-your-oauth-token-here
 ANTHROPIC_BASE_URL=http://localhost:4000
 
 # Optional: Override the default model


### PR DESCRIPTION
## What

`examples/python/.env.example` line 9 carried a real `sk-ant-oat01` Claude Code OAuth access token as an uncommented value. Replaced with a placeholder matching the style already used on line 5.

Also adds `.conductor/` to `.gitignore`.

## Why

Reported privately by a downstream fork maintainer. The repo is public, so the value was readable for about 12.5 months.

**The token has been revoked.** That is the part that actually ends the exposure. This PR does not: the blob stays reachable by commit SHA until garbage collection, and all 10 forks keep their own copy. This stops the value being served from the default branch going forward.

## Scope, verified

| Check | Result |
|---|---|
| Real Anthropic credentials in **all** history blobs | Exactly 1, this one |
| Remote branches carrying it | 26 of 27 (all but `dat-working-branch`) |
| Introduced | `6f8e7c8`, 2025-08-15 |
| Other `sk-ant` matches in tree | Documentation placeholders (`sk-ant-oat01-...`, `sk-ant-api03-your-key-here`) |
| Postgres DSNs | `<password>` literal + `${POSTGRES_PASSWORD:-litellm123}` local default |

The reporter's account was accurate on the finding, and undercounted the spread: they saw main plus six branches, and dated it to 08-13. The 08-13 and 08-14 commits carried only the placeholder API key.

## Why `.conductor/`

`.gitignore` covered `.env` but not `.env.example`, correctly, since the example file is committed by design. So the one file guaranteed to be public is the one that got a real token pasted into it. Nothing was positioned to catch that.

It was set to recur: `.conductor/` was untracked but not ignored, and an agent worktree there holds its own filled-in `.env.example` with a real-format token. A `git add -A` would have staged it.

## Follow-up

Secret scanning was **disabled** on this repo, which is why GitHub never alerted and an outside contributor had to find it manually. Being enabled alongside this PR, with push protection, so the next one is blocked at push time rather than found a year later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)