### PR TITLE
docs: subagent cost attribution recipe + headless capture note

### DIFF
--- a/docs/proxy-setup.md
+++ b/docs/proxy-setup.md
@@ -62,6 +62,28 @@ The wrapper script:
 - Configures Claude Code to route through LiteLLM
 - Passes OAuth tokens automatically
 
+### Headless and scripted runs (`-p`)
+
+Unrecognised arguments are passed straight through to Claude Code, so headless runs work as
+you'd expect and **are captured**:
+
+```bash
+./claude-lens -p "summarise this repo"
+```
+
+`claude -p` invoked directly is **not** captured. It never sees `ANTHROPIC_BASE_URL`, so it
+talks to the API host and produces no spans. This is easy to miss because nothing fails — the
+run succeeds, it just leaves no trace. The local transcript under `~/.claude/projects/` is
+still written either way, so the data isn't lost; only the telemetry is. If a script, cron
+job, CI step, or `Task`-style worker shells out to `claude`, point it at `claude-lens`.
+
+> **Don't "fix" this by putting `ANTHROPIC_BASE_URL` in `~/.claude/settings.json`.**
+> It looks like a one-line way to catch every invocation, but it makes *all* Claude Code usage
+> hard-depend on the proxy being reachable — when the container is down or you're off the
+> network that hosts it, Claude stops working entirely rather than merely going untraced.
+> The wrapper's health check exists precisely so that failure is explicit and scoped to runs
+> you asked to trace.
+
 ### Custom Proxy URL
 
 ```bash

--- a/docs/query-cookbook.md
+++ b/docs/query-cookbook.md
@@ -30,7 +30,7 @@ con.execute(f"ATTACH '{os.environ['PHOENIX_SQL_DATABASE_URL']}' AS pg (TYPE post
 
 Keep that `con` — the recipes below run in the **same `uv run python` session**: recipes #1
 and #2 each rebuild `con` so they stand alone, but #3–#4 reuse the `con` above, and the
-bare-```sql``` recipes (#5–#9) run by wrapping the SQL: `con.execute("""<sql>""").df()`.
+bare-```sql``` recipes (#5–#11) run by wrapping the SQL: `con.execute("""<sql>""").df()`.
 
 **There are two surfaces, not one.** `phoenix.spans` is what the *model* saw and said.
 `<workspace_*>.sandbox_agent_events` is what the *agent* did — tool calls, statuses,
@@ -648,6 +648,66 @@ and `usage_object.reasoning_tokens` is ~always 0 (65 non-zero of 28,578 field-ca
 "How many tokens went to reasoning?" is not answerable on this path — don't build a report on
 it. Cache accounting IS real: `usage_object.cache_read/creation_input_tokens` non-zero on ~90%
 of carrying spans.
+
+## 11. Main loop vs. subagents (who actually spent the tokens)
+
+Claude Code stamps two headers on every request it makes, and LiteLLM preserves them under
+`attributes->'metadata'->'requester_custom_headers'`:
+
+| header | meaning |
+|--------|---------|
+| `x-claude-code-session-id` | the conversation thread |
+| `x-claude-code-agent-id`   | **present only on subagent (Task tool) calls** |
+
+So the main loop is the *absence* of the agent header, and each subagent is one distinct id.
+No extra instrumentation is needed — this is stock Claude Code behaviour.
+
+```sql
+SELECT * FROM postgres_query('pg', $$
+  SELECT coalesce(attributes->'metadata'->'requester_custom_headers'->>'x-claude-code-agent-id',
+                  '(main loop)') AS agent_id,
+         count(*) AS calls,
+         sum(coalesce(llm_token_count_prompt,0))     AS prompt_tokens,
+         sum(coalesce(llm_token_count_completion,0)) AS completion_tokens
+  FROM phoenix.spans
+  WHERE name = 'litellm_request'
+    AND start_time > now() - INTERVAL '2 days'
+  GROUP BY 1 ORDER BY 2 DESC
+$$);
+```
+
+Swap the time filter for
+`… ->>'x-claude-code-session-id' = '<session-uuid>'` to break one session into its main loop
+plus each subagent it spawned. Subagent calls carry the parent session id too, so the join
+back to the parent is free.
+
+**⚠️ Only `litellm_request` carries these headers.** Measured over a 2-day window: 8,001
+`litellm_request` spans, 100% with a session id and ~51% with an agent id — and **zero** on
+all seven other span names (`raw_gen_ai_request`, `Claude_Code_Internal_Prompt_*`,
+`Claude_Code_Tool_*`, `Claude_Code_Final_Output_*`, `claude_code.UserPromptSubmit`). This is
+the same span-type artifact that bites `account_uuid` in [Recipe 1](#1-who-is-active-the-team-roster):
+group without `WHERE name = 'litellm_request'` and the bulk of your corpus lands under
+`(main loop)` by construction, making subagent work look like it never happened.
+
+Two more traps, both of which produced a wrong "DAL isn't capturing this" conclusion before
+this recipe was written:
+
+- **The `agent-` prefix is not on the wire.** Local sidecars are
+  `~/.claude/projects/<enc-cwd>/<session>/subagents/agent-<id>.jsonl`, but the header value is
+  the bare `<id>`. Grepping the filename against `attributes::text` returns 0 rows and reads
+  as absence.
+- **Don't bound by the session's first day.** A session resumed a week later spawns subagents
+  with timestamps far from its start. Filter on the session id, not a `BETWEEN` window around
+  it, or you will silently drop the later ones.
+
+**Agent *type* is not in the headers** — only the opaque id. `agentType` (`Explore`, `Plan`,
+`general-purpose`, …) exists solely in the local sidecar
+`subagents/agent-<id>.meta.json`, so "cost by agent kind" needs a sidecar join at sync time.
+Tracked in ENG2-1590.
+
+Finally, the "`session_id` is NOT a working session" caveat in [querying.md](querying.md)
+applies to `x-claude-code-session-id` as well: it is a conversation thread that survives
+`--continue`/`--resume`, **not** a working session. Don't `GROUP BY` it to count sessions.
 
 ---
 


### PR DESCRIPTION
## Why

Investigating "are we even capturing subagent work?" produced two wrong "we need to build this" conclusions before the answer turned out to be **we already have it**. Documenting the recipe so nobody re-derives it, and the three traps that make working capture look broken.

## What

**`docs/query-cookbook.md` — new Recipe 11: main loop vs. subagents.**

Claude Code stamps two headers on every request; LiteLLM preserves both under `attributes->'metadata'->'requester_custom_headers'`:

| header | meaning |
|---|---|
| `x-claude-code-session-id` | the conversation thread |
| `x-claude-code-agent-id` | present **only** on subagent (Task tool) calls |

Main loop = absence of the agent header. Per-subagent token cost is one `GROUP BY`. No instrumentation needed — stock Claude Code behaviour.

Three documented traps, each of which independently produced a false "DAL isn't capturing this":

1. **Headers exist only on `litellm_request`.** Measured over 2 days: 8,001 `litellm_request` spans, 100% with a session id, ~51% with an agent id — and **zero** on all seven other span names. Same span-type artifact that bites `account_uuid` in Recipe 1; group without the name filter and subagent work vanishes into `(main loop)`.
2. **The `agent-` prefix isn't on the wire.** Sidecars are `agent-<id>.jsonl`; the header is the bare `<id>`. Grepping the filename returns 0 rows and reads as absence.
3. **Don't bound by the session's first day.** A resumed session spawns subagents days later; a `BETWEEN` window around the session start silently drops them.

**`docs/proxy-setup.md` — new "Headless and scripted runs (`-p`)".**

`./claude-lens -p "..."` is captured (the wrapper already passes unrecognised args through). A bare `claude -p` is **not** — it never sees `ANTHROPIC_BASE_URL`, produces no spans, and nothing fails, so it's easy to miss. Local transcripts are still written either way; only telemetry is lost.

Includes a callout against the tempting "fix" of putting `ANTHROPIC_BASE_URL` in `~/.claude/settings.json`: it converts a silently-untraced run into a **hard dependency on proxy reachability**, so Claude breaks entirely whenever the proxy is down or you're off its network. The wrapper's health check exists so that failure is explicit and scoped.

## Verification

Recipe 11's SQL was run verbatim against the live backend — 74 rows, 73 distinct subagents over a 2-day window. Header coverage table measured, not inferred. No internal hostnames, DSNs, customer names, or real session UUIDs in the diff.

## Follow-up

Agent *type* (`Explore`, `Plan`, …) is sidecar-only — the wire header carries just the opaque id, so "cost by agent kind" needs a sidecar join at sync time. Tracked in ENG2-1590.

## Not included (flagging for a maintainer)

`claude-lens` health-checks with `curl -s`, which exits 0 on an HTTP 500 — so a proxy returning an error page passes the check. `claude-lens-v2` uses `curl -sf` and gets this right. Left out deliberately to keep this docs-only, and because v2's status looks like an in-flight migration I didn't want to presume on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)